### PR TITLE
Use Stork Registry in Publisher Agent

### DIFF
--- a/cli/stork-publisher-agent/config.go
+++ b/cli/stork-publisher-agent/config.go
@@ -12,7 +12,8 @@ type StorkPublisherAgentConfig struct {
 	DeltaCheckPeriod               time.Duration
 	ChangeThresholdProportion      float64 // 0-1
 	OracleId                       OracleId
-	OutgoingWsUrlsAndAuths         map[string]AuthToken
+	StorkRegistryBaseUrl           string
+	StorkAuth                      AuthToken
 	PullBasedWsUrl                 string
 	PullBasedAuth                  AuthToken
 	PullBasedWsSubscriptionRequest string
@@ -28,7 +29,8 @@ func NewStorkPublisherAgentConfig(
 	deltaPeriod time.Duration,
 	changeThresholdPercentage float64,
 	oracleId OracleId,
-	outgoingWsUrlsAndAuths map[string]AuthToken,
+	storkRegistryBaseUrl string,
+	storkAuth AuthToken,
 	pullBasedWsUrl string,
 	pullBasedAuth AuthToken,
 	pullBasedWsSubscriptionRequest string,
@@ -43,7 +45,8 @@ func NewStorkPublisherAgentConfig(
 		DeltaCheckPeriod:               deltaPeriod,
 		ChangeThresholdProportion:      changeThresholdPercentage / 100.0,
 		OracleId:                       oracleId,
-		OutgoingWsUrlsAndAuths:         outgoingWsUrlsAndAuths,
+		StorkRegistryBaseUrl:           storkRegistryBaseUrl,
+		StorkAuth:                      storkAuth,
 		PullBasedWsUrl:                 pullBasedWsUrl,
 		PullBasedAuth:                  pullBasedAuth,
 		PullBasedWsSubscriptionRequest: pullBasedWsSubscriptionRequest,

--- a/cli/stork-publisher-agent/config.go
+++ b/cli/stork-publisher-agent/config.go
@@ -14,6 +14,8 @@ type StorkPublisherAgentConfig struct {
 	OracleId                       OracleId
 	StorkRegistryBaseUrl           string
 	StorkAuth                      AuthToken
+	StorkRegistryRefreshInterval   time.Duration
+	BrokerReconnectDelay           time.Duration
 	PullBasedWsUrl                 string
 	PullBasedAuth                  AuthToken
 	PullBasedWsSubscriptionRequest string
@@ -30,6 +32,8 @@ func NewStorkPublisherAgentConfig(
 	changeThresholdPercentage float64,
 	oracleId OracleId,
 	storkRegistryBaseUrl string,
+	storkRegistryRefreshInterval time.Duration,
+	brokerReconnectDelay time.Duration,
 	storkAuth AuthToken,
 	pullBasedWsUrl string,
 	pullBasedAuth AuthToken,
@@ -46,6 +50,8 @@ func NewStorkPublisherAgentConfig(
 		ChangeThresholdProportion:      changeThresholdPercentage / 100.0,
 		OracleId:                       oracleId,
 		StorkRegistryBaseUrl:           storkRegistryBaseUrl,
+		StorkRegistryRefreshInterval:   storkRegistryRefreshInterval,
+		BrokerReconnectDelay:           brokerReconnectDelay,
 		StorkAuth:                      storkAuth,
 		PullBasedWsUrl:                 pullBasedWsUrl,
 		PullBasedAuth:                  pullBasedAuth,

--- a/cli/stork-publisher-agent/model.go
+++ b/cli/stork-publisher-agent/model.go
@@ -94,3 +94,9 @@ type SignedPriceUpdateBatch[T Signature] map[AssetId]SignedPriceUpdate[T]
 type SubscriptionRequest struct {
 	Assets []AssetId `json:"assets"`
 }
+
+type BrokerPublishUrl string
+type BrokerConnectionConfig struct {
+	PublishUrl BrokerPublishUrl `json:"publish_url"`
+	AssetIds   []AssetId        `json:"asset_ids"`
+}

--- a/cli/stork-publisher-agent/registry.go
+++ b/cli/stork-publisher-agent/registry.go
@@ -1,0 +1,53 @@
+package stork_publisher_agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+type RegistryClient struct {
+	baseUrl   string
+	authToken AuthToken
+}
+
+func NewRegistryClient(baseUrl string, authToken AuthToken) *RegistryClient {
+	return &RegistryClient{
+		baseUrl:   baseUrl,
+		authToken: authToken,
+	}
+}
+
+func (c *RegistryClient) GetBrokersForPublisher(publisherKey PublisherKey) (map[BrokerPublishUrl]map[AssetId]struct{}, error) {
+	brokerEndpoint := c.baseUrl + "/v1/registry/brokers"
+	queryParams := url.Values{}
+	queryParams.Add("publisher_key", string(publisherKey))
+	authHeader := http.Header{"Authorization": []string{"Basic " + string(c.authToken)}}
+	response, err := RestQuery("GET", brokerEndpoint, queryParams, nil, authHeader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get broker list: %v", err)
+	}
+	var brokers []BrokerConnectionConfig
+	err = json.Unmarshal(response, &brokers)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal broker list: %v", err)
+	}
+
+	// combine all configs into a single asset map per url
+	brokerMap := make(map[BrokerPublishUrl]map[AssetId]struct{})
+	for _, broker := range brokers {
+		assetIds, exists := brokerMap[broker.PublishUrl]
+
+		if !exists {
+			assetIds = make(map[AssetId]struct{})
+			brokerMap[broker.PublishUrl] = assetIds
+		}
+
+		for _, asset := range broker.AssetIds {
+			assetIds[asset] = struct{}{}
+		}
+	}
+
+	return brokerMap, nil
+}

--- a/cli/stork-publisher-agent/rest.go
+++ b/cli/stork-publisher-agent/rest.go
@@ -1,0 +1,43 @@
+package stork_publisher_agent
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+func RestQuery(method string, baseUrl string, query url.Values, requestBody io.Reader, header http.Header) ([]byte, error) {
+	// Parse the base URL
+	parsedURL, err := url.Parse(baseUrl)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing url %s: %v", baseUrl, err)
+	}
+
+	if query != nil {
+		parsedURL.RawQuery = query.Encode()
+	}
+
+	urlString := parsedURL.String()
+	req, err := http.NewRequest(method, urlString, requestBody)
+	req.Header = header
+
+	if err != nil {
+		return nil, fmt.Errorf("error creating %s request for url %s: %v", method, urlString, err)
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error making %s request for url %s: %v", method, urlString, err)
+
+	}
+	defer resp.Body.Close()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response responseBody for %s request for url %s: %v", method, urlString, err)
+	}
+
+	return responseBody, nil
+}

--- a/cli/stork-publisher-agent/runner.go
+++ b/cli/stork-publisher-agent/runner.go
@@ -91,7 +91,7 @@ func (r *PublisherAgentRunner[T]) UpdateBrokerConnections() {
 
 func (r *PublisherAgentRunner[T]) RunBrokerConnectionUpdater() {
 	r.UpdateBrokerConnections()
-	for range time.Tick(10 * time.Minute) {
+	for range time.Tick(r.config.StorkRegistryRefreshInterval) {
 		r.UpdateBrokerConnections()
 	}
 }
@@ -240,8 +240,8 @@ func (r *PublisherAgentRunner[T]) RunOutgoingConnection(url BrokerPublishUrl, as
 			r.logger.Info().Msg("Outgoing websocket was removed - not reconnecting")
 			return
 		} else {
-			r.logger.Warn().Msg("Outgoing websocket writer thread failed - reconnecting in 5 seconds")
-			time.Sleep(5 * time.Second)
+			r.logger.Warn().Msgf("Outgoing websocket writer thread failed - reconnecting after %s", r.config.BrokerReconnectDelay)
+			time.Sleep(r.config.BrokerReconnectDelay)
 		}
 	}
 }

--- a/cli/stork-publisher-agent/runner.go
+++ b/cli/stork-publisher-agent/runner.go
@@ -15,7 +15,9 @@ type PublisherAgentRunner[T Signature] struct {
 	logger                  zerolog.Logger
 	priceUpdateCh           chan PriceUpdate
 	signedPriceBatchCh      chan SignedPriceUpdateBatch[T]
-	outgoingConnections     map[ConnectionId]*OutgoingWebsocketConnection[T]
+	registryClient          *RegistryClient
+	brokerMap               map[BrokerPublishUrl]map[AssetId]struct{}
+	outgoingConnections     map[BrokerPublishUrl]*OutgoingWebsocketConnection[T]
 	outgoingConnectionsLock sync.RWMutex
 	incomingConnections     map[ConnectionId]*IncomingWebsocketConnection
 	incomingConnectionsLock sync.RWMutex
@@ -31,17 +33,66 @@ func NewPublisherAgentRunner[T Signature](
 	if err != nil {
 		logger.Fatal().Err(err).Msg("failed to create signer")
 	}
+
+	registryClient := NewRegistryClient(
+		config.StorkRegistryBaseUrl,
+		config.StorkAuth,
+	)
 	return &PublisherAgentRunner[T]{
 		config:                  config,
 		logger:                  logger,
 		priceUpdateCh:           make(chan PriceUpdate, 4096),
 		signedPriceBatchCh:      make(chan SignedPriceUpdateBatch[T], 4096),
-		outgoingConnections:     make(map[ConnectionId]*OutgoingWebsocketConnection[T]),
+		registryClient:          registryClient,
+		brokerMap:               make(map[BrokerPublishUrl]map[AssetId]struct{}),
+		outgoingConnections:     make(map[BrokerPublishUrl]*OutgoingWebsocketConnection[T]),
 		outgoingConnectionsLock: sync.RWMutex{},
 		incomingConnections:     make(map[ConnectionId]*IncomingWebsocketConnection),
 		incomingConnectionsLock: sync.RWMutex{},
 		upgrader:                GetWsUpgrader(),
 		signer:                  *signer,
+	}
+}
+
+func (r *PublisherAgentRunner[T]) UpdateBrokerConnections() {
+	r.logger.Info().Msg("Running broker connection updater")
+
+	// query Stork Registry for brokers
+	newBrokerMap, err := r.registryClient.GetBrokersForPublisher(r.config.PublicKey)
+	if err != nil {
+		r.logger.Error().Err(err).Msg("failed to get broker connections from Stork Registry")
+		return
+	}
+
+	// add or update desired connections
+	for brokerUrl, newAssetIdMap := range newBrokerMap {
+		_, exists := r.brokerMap[brokerUrl]
+		if exists {
+			// update connection
+			r.outgoingConnections[brokerUrl].UpdateAssets(newAssetIdMap)
+		} else {
+			// create connection
+			go r.RunOutgoingConnection(brokerUrl, newAssetIdMap, r.config.StorkAuth)
+		}
+		r.brokerMap[brokerUrl] = newAssetIdMap
+	}
+
+	// remove undesired connections
+	for url, _ := range r.brokerMap {
+		_, exists := newBrokerMap[url]
+		if !exists {
+			r.outgoingConnections[url].Remove()
+			delete(r.brokerMap, url)
+		}
+	}
+
+	r.logger.Info().Msg("Broker connection updater finished")
+}
+
+func (r *PublisherAgentRunner[T]) RunBrokerConnectionUpdater() {
+	r.UpdateBrokerConnections()
+	for range time.Tick(10 * time.Minute) {
+		r.UpdateBrokerConnections()
 	}
 }
 
@@ -68,9 +119,7 @@ func (r *PublisherAgentRunner[T]) Run() {
 		}
 	}(r.signedPriceBatchCh)
 
-	for outgoingWsUrl, outgoingWsAuth := range r.config.OutgoingWsUrlsAndAuths {
-		go r.RunOutgoingConnection(outgoingWsUrl, outgoingWsAuth)
-	}
+	go r.RunBrokerConnectionUpdater()
 
 	if len(r.config.PullBasedWsUrl) > 0 {
 		go r.RunPullBasedIncomingConnection(
@@ -147,7 +196,7 @@ func (r *PublisherAgentRunner[T]) RunPullBasedIncomingConnection(url string, aut
 	}
 }
 
-func (r *PublisherAgentRunner[T]) RunOutgoingConnection(url string, authToken AuthToken) {
+func (r *PublisherAgentRunner[T]) RunOutgoingConnection(url BrokerPublishUrl, assetIds map[AssetId]struct{}, authToken AuthToken) {
 	for {
 		r.logger.Info().Msgf("Connecting to outgoing WebSocket with url %s", url)
 
@@ -156,7 +205,7 @@ func (r *PublisherAgentRunner[T]) RunOutgoingConnection(url string, authToken Au
 			headers = http.Header{"Authorization": []string{"Basic " + string(authToken)}}
 		}
 
-		conn, _, err := websocket.DefaultDialer.Dial(url, headers)
+		conn, _, err := websocket.DefaultDialer.Dial(string(url), headers)
 		if err != nil {
 			r.logger.Error().Err(err).Msgf("Failed to connect to outgoing WebSocket: %v", err)
 			break
@@ -173,21 +222,27 @@ func (r *PublisherAgentRunner[T]) RunOutgoingConnection(url string, authToken Au
 			func() {
 				r.logger.Info().Str("auth_token", string(authToken)).Str("conn_id", string(connId)).Msg("removing subscriber websocket")
 				r.outgoingConnectionsLock.Lock()
-				delete(r.outgoingConnections, connId)
+				delete(r.outgoingConnections, url)
 				r.outgoingConnectionsLock.Unlock()
 			},
 		)
-		outgoingWebsocketConn := NewOutgoingWebsocketConnection[T](websocketConn, r.logger)
+		outgoingWebsocketConn := NewOutgoingWebsocketConnection[T](websocketConn, assetIds, r.logger)
 
 		// add subscriber to list
 		r.outgoingConnectionsLock.Lock()
-		r.outgoingConnections[connId] = outgoingWebsocketConn
+		r.outgoingConnections[url] = outgoingWebsocketConn
 		r.outgoingConnectionsLock.Unlock()
 
-		// read until a failure happens
+		// read until a failure happens or the connection is closed
 		outgoingWebsocketConn.Writer()
-		r.logger.Warn().Msg("Outgoing websocket writer thread failed - reconnecting in 5 seconds")
-		time.Sleep(5 * time.Second)
+
+		if outgoingWebsocketConn.removed {
+			r.logger.Info().Msg("Outgoing websocket was removed - not reconnecting")
+			return
+		} else {
+			r.logger.Warn().Msg("Outgoing websocket writer thread failed - reconnecting in 5 seconds")
+			time.Sleep(5 * time.Second)
+		}
 	}
 }
 

--- a/cli/stork-publisher-agent/websocket.go
+++ b/cli/stork-publisher-agent/websocket.go
@@ -169,10 +169,15 @@ func (owc *OutgoingWebsocketConnection[T]) Writer() {
 
 			filteredPriceUpdates := make(SignedPriceUpdateBatch[T])
 			owc.assetIdsLock.RLock()
-			for asset, signedPriceUpdate := range signedPriceUpdateBatch {
-				_, exists := owc.assetIds[asset]
-				if exists {
-					filteredPriceUpdates[asset] = signedPriceUpdate
+			_, allAssets := owc.assetIds[WildcardSubscriptionAsset]
+			if allAssets {
+				filteredPriceUpdates = signedPriceUpdateBatch
+			} else {
+				for asset, signedPriceUpdate := range signedPriceUpdateBatch {
+					_, exists := owc.assetIds[asset]
+					if exists {
+						filteredPriceUpdates[asset] = signedPriceUpdate
+					}
 				}
 			}
 			owc.assetIdsLock.RUnlock()


### PR DESCRIPTION
## Change
Hit the Stork Registry hosted on the Stork Rest API  every 10 minutes to update which signed prices should be sent to which brokers.

## Testing
* all data comes through when we configure both stark and evm pubs to use assets `*`
* if we delete a `PublisherConnection` between a publisher and a broker in dynamo, within 10 minutes we see no data from that publisher in the aggregator
* if we restrict a `PublisherConnection` to only BTCUSD, all other symbols stop reporting to the aggregator
* if we recreate the deleted `PublisherConnection` and restore the filter connection's assets to `*`, we see all data again in the aggregator