### PR TITLE
Build both arm64 and amd64 Docker images

### DIFF
--- a/scripts/initialize_docker.sh
+++ b/scripts/initialize_docker.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+docker login
+docker buildx create --use --name stork-cli-builder --driver docker-container

--- a/scripts/push_to_docker.sh
+++ b/scripts/push_to_docker.sh
@@ -5,7 +5,6 @@ set -e
 TAG="v1.0.0"
 DOCKERHUB_USERNAME="storknetwork"
 IMAGE_NAME="stork-cli"
-docker build -f "$IMAGE_NAME".Dockerfile -t "$IMAGE_NAME":"$TAG" .
-docker tag "$IMAGE_NAME":"$TAG" "$DOCKERHUB_USERNAME"/"$IMAGE_NAME":"$TAG"
-docker push "$DOCKERHUB_USERNAME"/"$IMAGE_NAME":"$TAG"
+docker buildx use stork-cli-builder
+docker buildx build --platform linux/amd64,linux/arm64 -f "$IMAGE_NAME".Dockerfile -t "$DOCKERHUB_USERNAME"/"$IMAGE_NAME":"$TAG" --push .
 echo "Pushed image successfully"

--- a/scripts/push_to_docker.sh
+++ b/scripts/push_to_docker.sh
@@ -6,5 +6,5 @@ TAG="v1.0.0"
 DOCKERHUB_USERNAME="storknetwork"
 IMAGE_NAME="stork-cli"
 docker buildx use stork-cli-builder
-docker buildx build --platform linux/amd64,linux/arm64 -f "$IMAGE_NAME".Dockerfile -t "$DOCKERHUB_USERNAME"/"$IMAGE_NAME":"$TAG" --push --progress=plain --no-cache .
+docker buildx build --platform linux/amd64,linux/arm64 -f "$IMAGE_NAME".Dockerfile -t "$DOCKERHUB_USERNAME"/"$IMAGE_NAME":"$TAG" --push --progress=plain .
 echo "Pushed image successfully"

--- a/scripts/push_to_docker.sh
+++ b/scripts/push_to_docker.sh
@@ -6,5 +6,5 @@ TAG="v1.0.0"
 DOCKERHUB_USERNAME="storknetwork"
 IMAGE_NAME="stork-cli"
 docker buildx use stork-cli-builder
-docker buildx build --platform linux/amd64,linux/arm64 -f "$IMAGE_NAME".Dockerfile -t "$DOCKERHUB_USERNAME"/"$IMAGE_NAME":"$TAG" --push .
+docker buildx build --platform linux/amd64,linux/arm64 -f "$IMAGE_NAME".Dockerfile -t "$DOCKERHUB_USERNAME"/"$IMAGE_NAME":"$TAG" --push --progress=plain --no-cache .
 echo "Pushed image successfully"

--- a/stork-cli.Dockerfile
+++ b/stork-cli.Dockerfile
@@ -1,8 +1,8 @@
 # Stage 1a: Build the Rust library for arm64
-FROM --platform=$BUILDPLATFORM rust:1.80.1-bookworm AS rust-build
+FROM rust:1.80-bookworm AS rust-build
 # Install cross-compilation tools
 RUN apt-get update &&\
-    apt-get install -y --no-install-recommends \
+    apt-get install -y \
     gcc-aarch64-linux-gnu \
     libc6-dev-arm64-cross \
     g++-x86-64-linux-gnu libc6-dev-amd64-cross \
@@ -32,10 +32,10 @@ RUN case "$TARGETPLATFORM" in \
     cp /app/rust/stork/target/$TARGET/release/libstork.so /usr/local/lib/
 
 # Stage 2: Build the Go Library
-FROM --platform=$BUILDPLATFORM golang:1.22-bookworm AS go-build
+FROM golang:1.22-bookworm AS go-build
 
 # Install cross-compilation tools
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y \
     gcc-aarch64-linux-gnu \
     libc6-dev-arm64-cross \
     g++-x86-64-linux-gnu libc6-dev-amd64-cross \

--- a/stork-cli.Dockerfile
+++ b/stork-cli.Dockerfile
@@ -1,4 +1,4 @@
-# Stage 1a: Build the Rust library for arm64
+# Stage 1: Build the Rust binary
 FROM rust:1.80-bookworm AS rust-build
 # Install cross-compilation tools
 RUN apt-get update &&\

--- a/stork-cli.Dockerfile
+++ b/stork-cli.Dockerfile
@@ -1,35 +1,44 @@
-# Stage 1: Build the Rust library
-FROM rust:1.70-buster AS rust-build
-
+# Stage 1a: Build the Rust library for arm64
+FROM --platform=$BUILDPLATFORM rust:1.80.1-bookworm AS rust-build
 # Install cross-compilation tools
-RUN apt-get update && apt-get install -y \
+RUN apt-get update &&\
+    apt-get install -y --no-install-recommends \
     gcc-aarch64-linux-gnu \
     libc6-dev-arm64-cross \
+    g++-x86-64-linux-gnu libc6-dev-amd64-cross \
     build-essential \
     curl \
     git \
     bash
 
-# Add the ARM64 target
-RUN rustup target add aarch64-unknown-linux-gnu
 
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc
 
 WORKDIR /app/rust/stork
 
 # Copy the Rust source code into the container
 COPY rust/stork .
 
-# Install dependencies and build the Rust library for arm64
-RUN cargo build --release --target aarch64-unknown-linux-gnu
+# Install dependencies and build the Rust library depending on the target platform
+ARG TARGETPLATFORM
+RUN case "$TARGETPLATFORM" in \
+        "linux/amd64")  export TARGET="x86_64-unknown-linux-gnu" ;; \
+        "linux/arm64")  export TARGET="aarch64-unknown-linux-gnu" ;; \
+        *) echo "Unsupported platform: $TARGETPLATFORM" ; exit 1 ;; \
+    esac && \
+    rustup target add $TARGET && \
+    cargo build --release --target $TARGET && \
+    cp /app/rust/stork/target/$TARGET/release/libstork.so /usr/local/lib/
 
 # Stage 2: Build the Go Library
-FROM golang:1.22-bullseye AS go-build
+FROM --platform=$BUILDPLATFORM golang:1.22-bookworm AS go-build
 
 # Install cross-compilation tools
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc-aarch64-linux-gnu \
     libc6-dev-arm64-cross \
+    g++-x86-64-linux-gnu libc6-dev-amd64-cross \
     build-essential
 
 WORKDIR /app/cli
@@ -43,15 +52,22 @@ COPY cli/ .
 # Copy the Rust library from the rust-build stage
 COPY rust/ /app/rust/
 
-COPY --from=rust-build /app/rust/stork/target/aarch64-unknown-linux-gnu/release/libstork.so /usr/local/lib/
+COPY --from=rust-build /usr/local/lib/libstork.so /usr/local/lib/
 ENV LD_LIBRARY_PATH=/usr/local/lib
 
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=arm64 go build -o /stork .
+ARG TARGETPLATFORM
+RUN case "$TARGETPLATFORM" in \
+        "linux/amd64")  export GOARCH="amd64" && export CC="x86_64-linux-gnu-gcc";; \
+        "linux/arm64")  export GOARCH="arm64" && export CC="aarch64-linux-gnu-gcc";; \
+        *) echo "Unsupported platform: $TARGETPLATFORM" ; exit 1 ;; \
+    esac && \
+    CGO_ENABLED=1 GOOS=linux GOARCH=$GOARCH CC=$CC go build -o /stork .
 
 # Stage 3: Create the final image
-FROM debian:buster-slim
+FROM --platform=$BUILDPLATFORM debian:bookworm-slim
 COPY --from=go-build /stork /usr/local/bin/stork
-COPY --from=rust-build /app/rust/stork/target/aarch64-unknown-linux-gnu/release/libstork.so /usr/local/lib/
+
+COPY --from=rust-build /usr/local/lib/libstork.so /usr/local/lib/
 ENV LD_LIBRARY_PATH=/usr/local/lib
 
 RUN apt-get update && apt-get install -y \

--- a/stork-cli.Dockerfile
+++ b/stork-cli.Dockerfile
@@ -64,9 +64,9 @@ RUN case "$TARGETPLATFORM" in \
     CGO_ENABLED=1 GOOS=linux GOARCH=$GOARCH CC=$CC go build -o /stork .
 
 # Stage 3: Create the final image
-FROM --platform=$BUILDPLATFORM debian:bookworm-slim
-COPY --from=go-build /stork /usr/local/bin/stork
+FROM debian:bookworm-slim
 
+COPY --from=go-build /stork /usr/local/bin/stork
 COPY --from=rust-build /usr/local/lib/libstork.so /usr/local/lib/
 ENV LD_LIBRARY_PATH=/usr/local/lib
 
@@ -74,4 +74,5 @@ RUN apt-get update && apt-get install -y \
     libc6 \
     libpthread-stubs0-dev \
     ca-certificates
+
 ENTRYPOINT ["/usr/local/bin/stork"]


### PR DESCRIPTION
Use one Dockerfile to build images for both amd64 and arm64 which run successfully on x86_64 and aarch64 EC2 machines.