### PR TITLE
[Publisher Agent] Reconnect if the Broker Dies

### DIFF
--- a/cli/stork-publisher-agent/runner.go
+++ b/cli/stork-publisher-agent/runner.go
@@ -37,16 +37,16 @@ func NewPublisherAgentRunner[T Signature](
 		config.StorkAuth,
 	)
 	return &PublisherAgentRunner[T]{
-		config:                  config,
-		signatureType:           signatureType,
-		logger:                  logger,
-		ValueUpdateCh:           make(chan ValueUpdate, 4096),
-		signedPriceBatchCh:      make(chan SignedPriceUpdateBatch[T], 4096),
-		registryClient:          registryClient,
-		assetsByBroker:          make(map[BrokerPublishUrl]map[AssetId]struct{}),
-		outgoingConnections:     make(map[BrokerPublishUrl]*OutgoingWebsocketConnection[T]),
-		outgoingConnectionsLock: sync.RWMutex{},
-		signer:                  *signer,
+		config:                      config,
+		signatureType:               signatureType,
+		logger:                      logger,
+		ValueUpdateCh:               make(chan ValueUpdate, 4096),
+		signedPriceBatchCh:          make(chan SignedPriceUpdateBatch[T], 4096),
+		registryClient:              registryClient,
+		assetsByBroker:              make(map[BrokerPublishUrl]map[AssetId]struct{}),
+		outgoingConnectionsByBroker: make(map[BrokerPublishUrl]*OutgoingWebsocketConnection[T]),
+		outgoingConnectionsLock:     sync.RWMutex{},
+		signer:                      *signer,
 	}
 }
 

--- a/cli/stork-publisher-agent/runner.go
+++ b/cli/stork-publisher-agent/runner.go
@@ -76,10 +76,8 @@ func (r *PublisherAgentRunner[T]) UpdateBrokerConnections() {
 
 	// add or update desired connections
 	for brokerUrl, newAssetIdMap := range newBrokerMap {
-		_, brokerExists := r.brokerMap[brokerUrl]
 		outgoingConnection, outgoingConnectionExists := r.outgoingConnections[brokerUrl]
-
-		if brokerExists && outgoingConnectionExists {
+		if outgoingConnectionExists {
 			// update connection
 			outgoingConnection.UpdateAssets(newAssetIdMap)
 		} else {

--- a/cli/stork-publisher-agent/signer_test.go
+++ b/cli/stork-publisher-agent/signer_test.go
@@ -28,6 +28,7 @@ func TestSigner_GetSignedPriceUpdate_Evm(t *testing.T) {
 		"",
 		"",
 		time.Duration(0),
+		time.Duration(0),
 		false,
 		0,
 	)
@@ -84,6 +85,7 @@ func TestSigner_SignStark(t *testing.T) {
 		"",
 		"",
 		"",
+		time.Duration(0),
 		time.Duration(0),
 		false,
 		0,
@@ -145,6 +147,7 @@ func BenchmarkSigner_SignEvm(b *testing.B) {
 		"",
 		"",
 		time.Duration(0),
+		time.Duration(0),
 		false,
 		0,
 	)
@@ -184,6 +187,7 @@ func BenchmarkSigner_SignStark(b *testing.B) {
 		"",
 		"",
 		"",
+		time.Duration(0),
 		time.Duration(0),
 		false,
 		0,


### PR DESCRIPTION
# Change
We observed a case where the Broker logged a read timeout from the publisher agent and the publisher agent never reconnected, so the publisher agent's data stopped reaching the broker.

I reproduced this situation locally by setting the broker read timeout to 10 nanoseconds and triggering a disconnection, but the publisher agent correctly reconnected to the broker.

It may be the case that something else (like a network outage) caused the publisher agent to not be able to reach the broker for the duration of the read timeout, and meant that the publisher agent never got a close message and therefore never attempted to reconnect.

As a blanket fix, we add a write timeout to the publisher agent so that we'll attempt to reconnect to any broker if it takes more than 10 seconds to write to it. We'll also remove an unnecessary `break` from the reconnect loop - we should really never exit that loop unless we've deregistered the broker.

# Testing
Before making these changes, I ran the publisher agent and broker locally and then stopped the broker container, and observed that the publisher agent just hung infinitely and didn't log any errors or attempt to reconnect.

After these changes, the publisher agent attempts to reconnect every 5 seconds and when I start the broker container up again it resumes publishing normally.