### PR TITLE
Remove break from puller reconnect loop

### DIFF
--- a/cli/stork-publisher-agent/incoming_puller.go
+++ b/cli/stork-publisher-agent/incoming_puller.go
@@ -32,7 +32,8 @@ func (p *IncomingWebsocketPuller) Run() {
 		incomingWsConn, _, err := websocket.DefaultDialer.Dial(p.Url, headers)
 		if err != nil {
 			p.Logger.Error().Err(err).Msgf("Failed to connect to pull-based WebSocket: %v", err)
-			break
+			time.Sleep(p.ReconnectDelay)
+			continue
 		}
 
 		_, messageBytes, err := incomingWsConn.ReadMessage()
@@ -48,7 +49,8 @@ func (p *IncomingWebsocketPuller) Run() {
 			p.Logger.Debug().Msgf("Received subscription response: %s", subscriptionResponse)
 			if err != nil {
 				p.Logger.Error().Err(err).Msg("Failed to send subscription request to pull-based WebSocket")
-				break
+				time.Sleep(p.ReconnectDelay)
+				continue
 			}
 		}
 


### PR DESCRIPTION
# Change
Right now if we fail to connect to the pull-based websocket server we'll exit the for loop and never try to reconnect. We should instead just wait 5 seconds and reconnect like we do for other types of errors when reading from the pull-based websocket
