### PR TITLE
use current time for clock updates

### DIFF
--- a/cli/stork-publisher-agent/processor.go
+++ b/cli/stork-publisher-agent/processor.go
@@ -83,10 +83,15 @@ func (vup *ValueUpdateProcessor[T]) ClockUpdate() []ValueUpdateWithTrigger {
 	updates := make([]ValueUpdateWithTrigger, 0)
 
 	for _, valueUpdate := range vup.valueUpdates {
+		currentTimeValueUpdate := ValueUpdate{
+			PublishTimestamp: time.Now().UnixNano(),
+			Value:            valueUpdate.Value,
+			Asset:            valueUpdate.Asset,
+		}
 		updates = append(
 			updates,
 			ValueUpdateWithTrigger{
-				ValueUpdate: valueUpdate,
+				ValueUpdate: currentTimeValueUpdate,
 				TriggerType: ClockTriggerType,
 			},
 		)


### PR DESCRIPTION
# Change
The timestamp associated with a "clock" update should be the current time so that infrequently-updating publishers don't get all their updates rejected as too old.

# Testing
Ran the publisher agent locally and confirmed that even once we stop pushing new updates to the publisher agent, we keep getting aggregator output with increasing timestamps.