### PR TITLE
Clearer configuration error reporting

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -8,7 +8,7 @@ Stork signed data feeds are delivered off-chain from publishers to subscribers v
 
 Stork does not write this data to the chain directly by default, but any subscriber can choose to write the data to the chain if they so choose. This tool can be used to facilitate that process.
 
-See [Stork Pusher Docs](docs/chain_pusher).
+See [Stork Pusher Docs](docs/chain_pusher.md).
 
 ## Publisher Agent
 
@@ -16,4 +16,4 @@ The Stork Network receives signed data feeds from publishers and aggregates them
 
 The easiest way to become a Stork Publisher is to run the Stork Publisher Agent docker container on your infrastructure and send price updates to the Agent through a local websocket. The Stork Publisher Agent will sign your price updates with your private key and send them to the Stork Network.
 
-See [Stork Publisher Agent Docs](docs/publisher_agent).
+See [Stork Publisher Agent Docs](docs/publisher_agent.md).

--- a/apps/docs/publisher_agent.md
+++ b/apps/docs/publisher_agent.md
@@ -35,6 +35,8 @@ docker run --platform linux/arm64 --pull always --restart always --name publishe
 ```
 The command will pull the docker image from our registry and run it in detached mode. If the container crashes it will automatically restart. This example assumes your config files are located in `/home/ubuntu` and that you're using port 5216 for the incoming websocket.
 
+Check `docker logs -f publisher-agent` for any error logs once you've launched the agent.
+
 Note that you may need to change the `--platform` argument if you're using an amd64 architecture.
 
 You should run the publisher agent from infrastructure in Tokyo (ideally AWS availability zone `ap-northeast-1a`) to ensure your updates reach the Stork Network quickly.

--- a/apps/docs/publisher_agent.md
+++ b/apps/docs/publisher_agent.md
@@ -37,6 +37,7 @@ The command will pull the docker image from our registry and run it in detached 
 
 Note that you may need to change the `--platform` argument if you're using an amd64 architecture.
 
+You should run the publisher agent from infrastructure in Tokyo (ideally AWS availability zone `ap-northeast-1a`) to ensure your updates reach the Stork Network quickly.
 ### Publishing Prices
 To publish a price to the Stork Network, you can connect to your Stork Publisher Agent's local port and send prices for each asset.
 

--- a/apps/lib/publisher_agent/config.go
+++ b/apps/lib/publisher_agent/config.go
@@ -13,6 +13,7 @@ import (
 )
 
 var Hex32Regex = regexp.MustCompile(`^0x[0-9a-fA-F]+$`)
+var StorkAuthRegex = regexp.MustCompile(`^[0-9a-fA-F]+$`)
 
 const DefaultClockUpdatePeriod = "500ms"
 const DefaultDeltaUpdatePeriod = "10ms"
@@ -90,6 +91,7 @@ func LoadConfig(configFilePath string, keysFilePath string) (*StorkPublisherAgen
 	if configFile.SignatureTypes == nil || len(configFile.SignatureTypes) == 0 {
 		return nil, fmt.Errorf("must specify at least one signatureType")
 	}
+
 	for _, signatureType := range configFile.SignatureTypes {
 		switch signatureType {
 		case EvmSignatureType:
@@ -109,6 +111,10 @@ func LoadConfig(configFilePath string, keysFilePath string) (*StorkPublisherAgen
 		default:
 			return nil, fmt.Errorf("invalid signature type: %s", signatureType)
 		}
+	}
+
+	if !StorkAuthRegex.MatchString(string(keysFile.StorkAuth)) {
+		return nil, errors.New("stork auth token must a non-empty string made up only of hex characters")
 	}
 
 	if len(keysFile.OracleId) != 5 {

--- a/apps/lib/publisher_agent/config.go
+++ b/apps/lib/publisher_agent/config.go
@@ -13,7 +13,7 @@ import (
 )
 
 var Hex32Regex = regexp.MustCompile(`^0x[0-9a-fA-F]+$`)
-var StorkAuthRegex = regexp.MustCompile(`^[0-9a-fA-F]+$`)
+var StorkAuthRegex = regexp.MustCompile(`^[A-Za-z0-9+/]+={0,2}$`)
 
 const DefaultClockUpdatePeriod = "500ms"
 const DefaultDeltaUpdatePeriod = "10ms"
@@ -114,7 +114,7 @@ func LoadConfig(configFilePath string, keysFilePath string) (*StorkPublisherAgen
 	}
 
 	if !StorkAuthRegex.MatchString(string(keysFile.StorkAuth)) {
-		return nil, errors.New("stork auth token must a non-empty string made up only of hex characters")
+		return nil, errors.New("stork auth token must a non-empty base64 string")
 	}
 
 	if len(keysFile.OracleId) != 5 {

--- a/apps/lib/publisher_agent/model.go
+++ b/apps/lib/publisher_agent/model.go
@@ -94,3 +94,6 @@ type BrokerConnectionConfig struct {
 	PublishUrl BrokerPublishUrl `json:"publish_url"`
 	AssetIds   []AssetId        `json:"asset_ids"`
 }
+type RegistryErrorResponse struct {
+	Error string `json:"error"`
+}

--- a/apps/lib/publisher_agent/runner.go
+++ b/apps/lib/publisher_agent/runner.go
@@ -32,6 +32,7 @@ func NewPublisherAgentRunner[T signer.Signature](
 	registryClient := NewRegistryClient(
 		config.StorkRegistryBaseUrl,
 		config.StorkAuth,
+		logger,
 	)
 	return &PublisherAgentRunner[T]{
 		config:                      config,


### PR DESCRIPTION
# Change
Log more clearly for various types of configuration issues.

# Testing
If a user doesn't configure the stork auth, or configures a badly formatted auth like `username:password`, the publisher agent will exit with this log message:
```
Error: error loading config: stork auth token must a non-empty base64 string
```

If a user doesn't configure the private or public key for their configured signature type or passes a badly formatted key, the agent will exit with a log message like:
```
Error: error loading config: must pass a valid EVM public key
```

If the stork auth is well formed but not valid, the publisher will log this error (but not fail):
```
{"level":"error","application":"stork-publisher-agent","service":"runner","signature_type":"evm","error":"not authorized to query Stork Registry - check your configured StorkAuth","time":"2024-10-03T01:50:30.093097305Z","message":"failed to get broker connections from Stork Registry"}
```

If the user's public key is not in the Stork Registry we'll log this error (but not fail):
```
{"level":"warn","application":"stork-publisher-agent","service":"runner","signature_type":"evm","time":"2024-10-03T02:14:44.177937339Z","message":"no stork registry broker found for public key (0xEE992A2493bcf5f68A3cA395109c0dc02333FF85) - reach out to Stork to make sure you're whitelisted"}
```