### PR TITLE
build: improve cgo flag management

### DIFF
--- a/apps/lib/signer/cgo_flags.go
+++ b/apps/lib/signer/cgo_flags.go
@@ -1,0 +1,7 @@
+package signer
+
+/*
+#cgo LDFLAGS: -L./rust/stork/target/release -lstork
+#cgo CFLAGS: -I./rust/stork/src
+*/
+import "C"

--- a/apps/lib/signer/rust/stork/src/lib.rs
+++ b/apps/lib/signer/rust/stork/src/lib.rs
@@ -1,4 +1,3 @@
-use std::ptr::hash;
 use starknet_core::crypto::{pedersen_hash, Signature};
 use starknet_core::types::{FieldElement, FromByteArrayError};
 

--- a/apps/lib/signer/signer.go
+++ b/apps/lib/signer/signer.go
@@ -1,8 +1,6 @@
 package signer
 
 /*
-#cgo LDFLAGS: -L/app/rust/stork/target/aarch64-unknown-linux-gnu/release -L./rust/stork/target/release -lstork
-#cgo CFLAGS: -I/app/rust/stork/src -I./rust/stork/src
 #include "signing.h"
 */
 import "C"

--- a/apps/lib/signer/verifier.go
+++ b/apps/lib/signer/verifier.go
@@ -1,8 +1,6 @@
 package signer
 
 /*
-#cgo LDFLAGS: -L/app/rust/stork/target/aarch64-unknown-linux-gnu/release -L./rust/stork/target/release -lstork
-#cgo CFLAGS: -I/app/rust/stork/src -I./rust/stork/src
 #include "signing.h"
 */
 import "C"


### PR DESCRIPTION
The hard-coded paths CFLAGS and LDFLAGS work for the docker build we have specified here, but cause problems with downstream imports which have a different directory structure.

This change:
- removes the hardcoded paths to keep only the relative ones
- consolidates flags into a single .go source file to avoid linker warnings about duplicates
- bonus: fix unused import warning from cargo