### PR TITLE
Added tryFrom implementations from (&)AccountInfo to TemporalNumericV…

### DIFF
--- a/sdks/solana/stork-sdk/src/error.rs
+++ b/sdks/solana/stork-sdk/src/error.rs
@@ -5,4 +5,6 @@ use anchor_lang::error_code;
 pub enum GetTemporalNumericValueError {
     #[msg("The feed id is invalid")]
     InvalidFeedId,
+    #[msg("Error deserializing AccountInfo")]
+    DeserializationError,
 }

--- a/sdks/solana/stork-sdk/src/temporal_numeric_value.rs
+++ b/sdks/solana/stork-sdk/src/temporal_numeric_value.rs
@@ -40,4 +40,21 @@ impl TemporalNumericValueFeed {
         );
         Ok(self.latest_value.clone())
     }
+
+}
+
+impl<'info> TryFrom<&AccountInfo<'info>> for TemporalNumericValueFeed {
+    type Error = anchor_lang::error::Error;
+    fn try_from(info: &AccountInfo<'info>) -> Result<Self> {
+        let data: &[u8] = &info.data.borrow();
+        Self::try_deserialize(&mut data.as_ref()).map_err(|e| GetTemporalNumericValueError::DeserializationError.into())
+    }
+}
+
+impl<'info> TryFrom<AccountInfo<'info>> for TemporalNumericValueFeed {
+    type Error = anchor_lang::error::Error;
+    fn try_from(info: AccountInfo<'info>) -> Result<Self> {
+        let data: &[u8] = &info.data.borrow();
+        Self::try_deserialize(&mut data.as_ref()).map_err(|_| GetTemporalNumericValueError::DeserializationError.into())
+    }
 }

--- a/sdks/solana/stork-sdk/src/temporal_numeric_value.rs
+++ b/sdks/solana/stork-sdk/src/temporal_numeric_value.rs
@@ -47,7 +47,11 @@ impl<'info> TryFrom<&AccountInfo<'info>> for TemporalNumericValueFeed {
     type Error = anchor_lang::error::Error;
     fn try_from(info: &AccountInfo<'info>) -> Result<Self> {
         let data: &[u8] = &info.data.borrow();
-        Self::try_deserialize(&mut data.as_ref()).map_err(|e| GetTemporalNumericValueError::DeserializationError.into())
+        Self::try_deserialize(&mut data.as_ref())
+            .map_err(|e| {
+                msg!("Failed to deserialize TemporalNumericValueFeed: {}", e);
+                GetTemporalNumericValueError::DeserializationError.into()
+            })
     }
 }
 
@@ -55,6 +59,10 @@ impl<'info> TryFrom<AccountInfo<'info>> for TemporalNumericValueFeed {
     type Error = anchor_lang::error::Error;
     fn try_from(info: AccountInfo<'info>) -> Result<Self> {
         let data: &[u8] = &info.data.borrow();
-        Self::try_deserialize(&mut data.as_ref()).map_err(|_| GetTemporalNumericValueError::DeserializationError.into())
+        Self::try_deserialize(&mut data.as_ref())
+            .map_err(|e| {
+                msg!("Failed to deserialize TemporalNumericValueFeed: {}", e);
+                GetTemporalNumericValueError::DeserializationError.into()
+            })
     }
 }


### PR DESCRIPTION
This implementation (or some form of in-crate deserialization) is necessary for use with many projects on anchor 0.29.0, as there seems to have been breaking changes in the anchor deserialization trait implementations in 0.30.