### PR TITLE
Henry/sto 641 fix stork external ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   push:
-    branches:
-      - main
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches-ignore:
+    branches:
       - main
 
 jobs:


### PR DESCRIPTION
I've removed the ignore main for running this workflow on push. 

As it turns out, branches are restricted on which other branches caches they can use, however every branch can use the default branches cache, in this case main. This means, if we allow main to run the CI, it will generate caches, which then all branches will be able to pull from.

I have confirmed this in a private test repository.