### PR TITLE
Data Provider Skeleton Mockup

### DIFF
--- a/apps/lib/data_provider/configs/resources/source_config_schemas/skeleton.json
+++ b/apps/lib/data_provider/configs/resources/source_config_schemas/skeleton.json
@@ -8,6 +8,6 @@
     }
    // TODO: add all other possible fields from your config object
   },
-  "required": ["dataSourceId"], // TODO: add all other required fields here
+  "required": ["dataSource"], // TODO: add all other required fields here
   "additionalProperties": false
 }

--- a/apps/lib/data_provider/configs/resources/source_config_schemas/skeleton.json
+++ b/apps/lib/data_provider/configs/resources/source_config_schemas/skeleton.json
@@ -1,0 +1,13 @@
+{
+  "$id": "/resources/source_config_schemas/skeleton",
+  "type": "object",
+  "properties": {
+    "dataSource": {
+      "type": "string",
+      "const": "skeleton"
+    }
+   // TODO: add all other possible fields from your config object
+  },
+  "required": ["dataSourceId"], // TODO: add all other required fields here
+  "additionalProperties": false
+}

--- a/apps/lib/data_provider/configs/resources/source_config_schemas/skeleton.json
+++ b/apps/lib/data_provider/configs/resources/source_config_schemas/skeleton.json
@@ -6,8 +6,7 @@
       "type": "string",
       "const": "skeleton"
     }
-   // TODO: add all other possible fields from your config object
   },
-  "required": ["dataSource"], // TODO: add all other required fields here
+  "required": ["dataSource"],
   "additionalProperties": false
 }

--- a/apps/lib/data_provider/configs/source_config_tests/skeleton_test.go
+++ b/apps/lib/data_provider/configs/source_config_tests/skeleton_test.go
@@ -27,7 +27,8 @@ func TestValidSkeletonConfig(t *testing.T) {
 
 	sourceSpecificConfig, err := skeleton.GetSourceSpecificConfig(sourceConfig)
 	assert.NoError(t, err)
+	assert.NotNil(t, sourceSpecificConfig)
 
 	// TODO: write some asserts to check that the fields on sourceSpecificConfig have the values you'd expect
-	panic("implement me")
+	t.Fatalf("implement me")
 }

--- a/apps/lib/data_provider/configs/source_config_tests/skeleton_test.go
+++ b/apps/lib/data_provider/configs/source_config_tests/skeleton_test.go
@@ -12,7 +12,17 @@ import (
 func TestValidSkeletonConfig(t *testing.T) {
 
 	// TODO: set this to a valid config string using a feed from your new source
-	validConfig := `{}`
+	validConfig := `
+	{
+	  "sources": [
+		{
+		  "id": "MY_VALUE",
+		  "config": {
+			"dataSource": "skeleton"
+		  }
+		}
+	  ]
+	}`
 
 	config, err := configs.LoadConfigFromBytes([]byte(validConfig))
 	assert.NoError(t, err)

--- a/apps/lib/data_provider/configs/source_config_tests/skeleton_test.go
+++ b/apps/lib/data_provider/configs/source_config_tests/skeleton_test.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/Stork-Oracle/stork-external/apps/lib/data_provider/configs"
+	"github.com/Stork-Oracle/stork-external/apps/lib/data_provider/sources/skeleton"
+	"github.com/Stork-Oracle/stork-external/apps/lib/data_provider/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidSkeletonConfig(t *testing.T) {
+
+	// TODO: set this to a valid config string using a feed from your new source
+	validConfig := `{}`
+
+	config, err := configs.LoadConfigFromBytes([]byte(validConfig))
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, len(config.Sources))
+
+	sourceConfig := config.Sources[0]
+
+	dataSourceId, err := utils.GetDataSourceId(sourceConfig.Config)
+	assert.NoError(t, err)
+	assert.Equal(t, skeleton.SkeletonDataSourceId, dataSourceId)
+
+	sourceSpecificConfig, err := skeleton.GetSourceSpecificConfig(sourceConfig)
+	assert.NoError(t, err)
+
+	// TODO: write some asserts to check that the fields on sourceSpecificConfig have the values you'd expect
+	panic("implement me")
+}

--- a/apps/lib/data_provider/sources/skeleton/config.go
+++ b/apps/lib/data_provider/sources/skeleton/config.go
@@ -1,0 +1,8 @@
+package skeleton
+
+import "github.com/Stork-Oracle/stork-external/apps/lib/data_provider/types"
+
+type SkeletonConfig struct {
+	DataSource types.DataSourceId `json:"dataSource"` // required for all Data Provider Sources
+	// TODO: Add any additional config parameters needed to pull a particular data feed
+}

--- a/apps/lib/data_provider/sources/skeleton/data_source.go
+++ b/apps/lib/data_provider/sources/skeleton/data_source.go
@@ -5,6 +5,7 @@ import (
 )
 
 type skeletonDataSource struct {
+	SkeletonConfig SkeletonConfig
 	// TODO: set any necessary parameters
 }
 
@@ -15,10 +16,12 @@ func newSkeletonDataSource(sourceConfig types.DataProviderSourceConfig) *skeleto
 	}
 
 	// TODO: add any necessary initialization code
-	panic("implement me")
+	return &skeletonDataSource{
+		SkeletonConfig: skeletonConfig,
+	}
 }
 
 func (r skeletonDataSource) RunDataSource(updatesCh chan types.DataSourceUpdateMap) {
-	// TODO: Write all logic to fetch datapoints and add to updatesCh
+	// TODO: Write all logic to fetch data points and report them to updatesCh
 	panic("implement me")
 }

--- a/apps/lib/data_provider/sources/skeleton/data_source.go
+++ b/apps/lib/data_provider/sources/skeleton/data_source.go
@@ -1,0 +1,24 @@
+package skeleton
+
+import (
+	"github.com/Stork-Oracle/stork-external/apps/lib/data_provider/types"
+)
+
+type skeletonDataSource struct {
+	// TODO: set any necessary parameters
+}
+
+func newSkeletonDataSource(sourceConfig types.DataProviderSourceConfig) *skeletonDataSource {
+	skeletonConfig, err := GetSourceSpecificConfig(sourceConfig)
+	if err != nil {
+		panic("unable to decode config: " + err.Error())
+	}
+
+	// TODO: add any necessary initialization code
+	panic("implement me")
+}
+
+func (r skeletonDataSource) RunDataSource(updatesCh chan types.DataSourceUpdateMap) {
+	// TODO: Write all logic to fetch datapoints and add to updatesCh
+	panic("implement me")
+}

--- a/apps/lib/data_provider/sources/skeleton/data_source_test.go
+++ b/apps/lib/data_provider/sources/skeleton/data_source_test.go
@@ -6,4 +6,5 @@ import (
 
 func TestSkeletonDataSource(t *testing.T) {
 	// TODO: write some unit tests for your data source
+	t.Fatalf("implement me")
 }

--- a/apps/lib/data_provider/sources/skeleton/data_source_test.go
+++ b/apps/lib/data_provider/sources/skeleton/data_source_test.go
@@ -1,0 +1,9 @@
+package skeleton
+
+import (
+	"testing"
+)
+
+func TestSkeletonDataSource(t *testing.T) {
+	// TODO: write some unit tests for your data source
+}

--- a/apps/lib/data_provider/sources/skeleton/init.go
+++ b/apps/lib/data_provider/sources/skeleton/init.go
@@ -1,0 +1,30 @@
+package skeleton
+
+import (
+	"github.com/Stork-Oracle/stork-external/apps/lib/data_provider/sources"
+	"github.com/Stork-Oracle/stork-external/apps/lib/data_provider/types"
+	"github.com/Stork-Oracle/stork-external/apps/lib/data_provider/utils"
+	"github.com/mitchellh/mapstructure"
+)
+
+var SkeletonDataSourceId types.DataSourceId = types.DataSourceId(utils.GetCurrentDirName())
+
+type skeletonDataSourceFactory struct{}
+
+func (f *skeletonDataSourceFactory) Build(sourceConfig types.DataProviderSourceConfig) types.DataSource {
+	return newSkeletonDataSource(sourceConfig)
+}
+
+func init() {
+	sources.RegisterDataSourceFactory(SkeletonDataSourceId, &skeletonDataSourceFactory{})
+}
+
+// assert we're satisfying our interfaces
+var _ types.DataSource = (*skeletonDataSource)(nil)
+var _ types.DataSourceFactory = (*skeletonDataSourceFactory)(nil)
+
+func GetSourceSpecificConfig(sourceConfig types.DataProviderSourceConfig) (SkeletonConfig, error) {
+	var config SkeletonConfig
+	err := mapstructure.Decode(sourceConfig.Config, &config)
+	return config, err
+}


### PR DESCRIPTION
We'd like to make adding a new Data Provider source easier by auto-generating some skeleton code which the user can then fill in so they don't have to think too much about the framework.

In this PR I've manually written some suggested skeleton code for a new data source called `skeleton`, which can hopefully serve as a starting model for our templating

I think the ideal flow for a user would be a CLI-like tool where we ask them to give us the name of their dataSource in `TitleCase`. We would then automatically
1. validate the string they gave us was valid (no underscores/spaces etc, not using the name of an existing dataSource)
2. do some templating to auto-generate all the files in this PR (including the TODO comments) with their dataSource name in place of`skeleton`. We can figure out `camelCase`,`snake_case` and `flatcase` versions of the dataSource name automatically and insert the appropriate one into the template.
3. run `python3 ./apps/scripts/update_shared_data_provider_code.py` to update a couple of shared framework files
4. Print a message to the user telling them to fill in all the TODOs (and maybe listing all the files containing a TODO)

Then the user just fills in the TODOs, gets their tests passing and submits the PR.