### PR TITLE
add nanosecond precision comments

### DIFF
--- a/contracts/stork_chainlink_adapter/README.md
+++ b/contracts/stork_chainlink_adapter/README.md
@@ -1,6 +1,7 @@
 # Stork Chainlink Adapter
 This contract is a light wrapper around the [Stork EVM contract](../evm) which conforms to Chainlink's [AggregatorV3Interface](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol).
 
+Note that all timestamps are in nanoseconds.
 
 ## Integrate with Your Solidity Contracts
 1. Install the Stork Chainlink Adapter npm package in your project

--- a/contracts/stork_chainlink_adapter/contracts/StorkChainlinkAdapter.sol
+++ b/contracts/stork_chainlink_adapter/contracts/StorkChainlinkAdapter.sol
@@ -30,12 +30,13 @@ contract StorkChainlinkAdapter {
         return stork.getTemporalNumericValueUnsafeV1(priceId).quantizedValue;
     }
 
+    // in nanoseconds
     function latestTimestamp() public view returns (uint256) {
         return stork.getTemporalNumericValueUnsafeV1(priceId).timestampNs;
     }
 
     function latestRound() public view returns (uint256) {
-        // use timestamp as the round id
+        // use timestamp in nanoseconds as the round id
         return latestTimestamp();
     }
 
@@ -43,6 +44,7 @@ contract StorkChainlinkAdapter {
         return latestAnswer();
     }
 
+    // in nanoseconds
     function getTimestamp(uint256) external view returns (uint256) {
         return latestTimestamp();
     }
@@ -50,6 +52,7 @@ contract StorkChainlinkAdapter {
     /*
     * @notice This is exactly the same as `latestRoundData`, just including for parity with Chainlink
     * Stork doesn't store roundId on chain so there's no way to access old data by round id
+    * Note that timestamps are in nanoseconds
     */
     function getRoundData(
         uint80 _roundId
@@ -74,6 +77,7 @@ contract StorkChainlinkAdapter {
         );
     }
 
+    // timestamps are in nanoseconds
     function latestRoundData()
     external
     view


### PR DESCRIPTION
Make more explicit that the chainlink adapter's timestamps are all in nanoseconds.