### PR TITLE
Add cronos l2 api key to docker-entrypoint.sh

### DIFF
--- a/contracts/evm/docker-entrypoint.sh
+++ b/contracts/evm/docker-entrypoint.sh
@@ -14,6 +14,7 @@ npx hardhat vars set ROOTSTOCK_TESTNET_API_KEY fake
 npx hardhat vars set SCROLL_MAINNET_API_KEY fake
 npx hardhat vars set SONEIUM_MAINNET_RPC_URL fake
 npx hardhat vars set SONEIUM_MAINNET_BLOCKSCOUT_URL fake
+npx hardhat vars set CRONOS_L2_API_KEY fake
 
 # Start hardhat node as a background process
 npx hardhat node &


### PR DESCRIPTION
Needed to add var from cronos deployment in 1 more spot