### PR TITLE
chore(ci): upgrade actions/cache to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Cache Go modules
         id: go-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build
@@ -42,7 +42,7 @@ jobs:
           fi
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -147,7 +147,7 @@ jobs:
           components: rustfmt
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -158,7 +158,7 @@ jobs:
             ${{ runner.os }}-cargo-solana-
 
       - name: Cache Solana CLI
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.local/share/solana/install
@@ -176,7 +176,7 @@ jobs:
           solana config set --url localhost
 
       - name: Cache Anchor CLI
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/anchor
@@ -209,7 +209,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -220,7 +220,7 @@ jobs:
             ${{ runner.os }}-cargo-sui-
 
       - name: Cache Sui CLI
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/sui
@@ -250,7 +250,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -285,7 +285,7 @@ jobs:
           pip install packaging
           
       - name: Cache Aptos CLI
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.aptos


### PR DESCRIPTION
Node 20 compatibility: switch all jobs to actions/cache@v4. Pure maintenance update, behaviour unchanged.