### PR TITLE
Upgrade to Go 1.24.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.24'
+          go-version: '1.24.3'
 
       - name: Cache Go modules
         id: go-cache
@@ -67,7 +67,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.24'
+          go-version: '1.24.3'
 
       - name: Install CLI directly
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder stage
-FROM golang:1.24-bookworm AS builder
+FROM golang:1.24.3-bookworm AS builder
 ARG TARGETPLATFORM
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Stork-Oracle/stork-external
 
-go 1.24.0
+go 1.24.3
 
 require (
 	cosmossdk.io/math v1.5.0


### PR DESCRIPTION
# Change
Upgrade to Go 1.24.0

# Testing
- [x] unit tests
- [x] integration tests
- [x] data provider docker image builds successfully
- [x] data provider runs successfully locally
- [x] publisher agent docker image builds successfully
- [x] publisher agent runs successfully locally
- [x] chain pusher docker image builds successfully
- [x] chain pusher runs successfully locally
- [x] generate runs successfully locally