### PR TITLE
chore: fix typo

### DIFF
--- a/examples/cosmwasm/cosmwasm_core/src/contract.rs
+++ b/examples/cosmwasm/cosmwasm_core/src/contract.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::{DepsMut, Env, MessageInfo, Response, StdError};
 
 // The sv module is the module that contains the sylvia macro expansion of the stork contract
 // It is not present when reading the stork contract unless you expand the macro with a tool like rust-analyzer
-// It containes useful things like the QueryMsg, ExecuteMsg, and more, and those messages can be imported like this:
+// It contains useful things like the QueryMsg, ExecuteMsg, and more, and those messages can be imported like this:
 use stork_cw::contract::sv::QueryMsg::GetLatestCanonicalTemporalNumericValueUnchecked;
 
 use stork_cw::responses::GetTemporalNumericValueResponse;


### PR DESCRIPTION
Fixed typo in [contract.rs](https://github.com/Stork-Oracle/stork-external/compare/main...sukrucildirr:stork-external:main?expand=1#diff-fa0ca3138487322b730019b50212ee01b94263f099712c6def903329c83e8b85)