### PR TITLE
Asset Whitelist Bugfix

### DIFF
--- a/apps/lib/publisher_agent/runner.go
+++ b/apps/lib/publisher_agent/runner.go
@@ -142,6 +142,7 @@ func (r *PublisherAgentRunner[T]) Run() {
 }
 
 func (r *PublisherAgentRunner[T]) RunOutgoingConnection(url BrokerPublishUrl, assetIds map[AssetId]struct{}) {
+	outgoingWebsocketConn := NewOutgoingWebsocketConnection[T](assetIds, r.logger)
 	for {
 		r.logger.Debug().Msgf("Connecting to receiver WebSocket with url %s", url)
 
@@ -169,7 +170,7 @@ func (r *PublisherAgentRunner[T]) RunOutgoingConnection(url BrokerPublishUrl, as
 				r.outgoingConnectionsLock.Unlock()
 			},
 		)
-		outgoingWebsocketConn := NewOutgoingWebsocketConnection[T](websocketConn, assetIds, r.logger)
+		outgoingWebsocketConn.SetWebsocketConn(websocketConn)
 
 		// add subscriber to list
 		r.outgoingConnectionsLock.Lock()

--- a/apps/lib/publisher_agent/runner.go
+++ b/apps/lib/publisher_agent/runner.go
@@ -76,6 +76,7 @@ func (r *PublisherAgentRunner[T]) UpdateBrokerConnections() {
 	}
 
 	// add or update desired connections
+	r.outgoingConnectionsLock.RLock()
 	for brokerUrl, newAssetIdMap := range newBrokerMap {
 		outgoingConnection, outgoingConnectionExists := r.outgoingConnectionsByBroker[brokerUrl]
 		if outgoingConnectionExists {
@@ -87,8 +88,10 @@ func (r *PublisherAgentRunner[T]) UpdateBrokerConnections() {
 		}
 		r.assetsByBroker[brokerUrl] = newAssetIdMap
 	}
+	r.outgoingConnectionsLock.RUnlock()
 
 	// remove undesired connections
+	r.outgoingConnectionsLock.Lock()
 	for url, _ := range r.assetsByBroker {
 		_, exists := newBrokerMap[url]
 		if !exists {
@@ -96,6 +99,7 @@ func (r *PublisherAgentRunner[T]) UpdateBrokerConnections() {
 			delete(r.assetsByBroker, url)
 		}
 	}
+	r.outgoingConnectionsLock.Unlock()
 
 	r.logger.Debug().Msg("Broker connection updater finished")
 }

--- a/apps/lib/publisher_agent/runner.go
+++ b/apps/lib/publisher_agent/runner.go
@@ -112,7 +112,7 @@ func (r *PublisherAgentRunner[T]) RunBrokerConnectionUpdater() {
 }
 
 func (r *PublisherAgentRunner[T]) Run() {
-	processor := NewPriceUpdateProcessor[T](
+	processor := NewPriceUpdateProcessor(
 		r.signer,
 		r.config.OracleId,
 		len(r.config.SignatureTypes),
@@ -175,7 +175,7 @@ func (r *PublisherAgentRunner[T]) RunOutgoingConnection(url BrokerPublishUrl, as
 				r.outgoingConnectionsLock.Unlock()
 			},
 		)
-		outgoingWebsocketConn := NewOutgoingWebsocketConnection[T](websocketConn, assets, r.logger)
+		outgoingWebsocketConn := NewOutgoingWebsocketConnection(websocketConn, assets, r.logger)
 
 		// add subscriber to list
 		r.outgoingConnectionsLock.Lock()

--- a/apps/lib/publisher_agent/websocket.go
+++ b/apps/lib/publisher_agent/websocket.go
@@ -168,34 +168,59 @@ func (iwc *IncomingWebsocketConnection) Reader(valueUpdateChannels []chan ValueU
 	}
 
 	iwc.Close()
+}
 
+type OutgoingWebsocketConnectionAssets[T signer.Signature] struct {
+	assetIds     map[AssetId]struct{}
+	assetIdsLock sync.RWMutex
+}
+
+func NewOutgoingWebsocketConnectionAssets[T signer.Signature](assetIds map[AssetId]struct{}) *OutgoingWebsocketConnectionAssets[T] {
+	return &OutgoingWebsocketConnectionAssets[T]{
+		assetIds:     assetIds,
+		assetIdsLock: sync.RWMutex{},
+	}
+}
+
+func (a *OutgoingWebsocketConnectionAssets[T]) filterSignedPriceUpdateBatch(signedPriceUpdateBatch SignedPriceUpdateBatch[T]) SignedPriceUpdateBatch[T] {
+	filteredPriceUpdates := make(SignedPriceUpdateBatch[T])
+	a.assetIdsLock.RLock()
+	_, allAssets := a.assetIds[WildcardSubscriptionAsset]
+	if allAssets {
+		filteredPriceUpdates = signedPriceUpdateBatch
+	} else {
+		for asset, signedPriceUpdate := range signedPriceUpdateBatch {
+			_, exists := a.assetIds[asset]
+			if exists {
+				filteredPriceUpdates[asset] = signedPriceUpdate
+			}
+		}
+	}
+	a.assetIdsLock.RUnlock()
+	return filteredPriceUpdates
+}
+
+func (a *OutgoingWebsocketConnectionAssets[T]) UpdateAssets(assetIds map[AssetId]struct{}) {
+	a.assetIdsLock.Lock()
+	a.assetIds = assetIds
+	a.assetIdsLock.Unlock()
 }
 
 type OutgoingWebsocketConnection[T signer.Signature] struct {
 	WebsocketConnection
-	assetIds                 map[AssetId]struct{}
-	assetIdsLock             sync.RWMutex
+	assets                   *OutgoingWebsocketConnectionAssets[T]
 	removed                  bool
 	logger                   zerolog.Logger
 	signedPriceUpdateBatchCh chan SignedPriceUpdateBatch[T]
 }
 
-func NewOutgoingWebsocketConnection[T signer.Signature](assetIds map[AssetId]struct{}, logger zerolog.Logger) *OutgoingWebsocketConnection[T] {
+func NewOutgoingWebsocketConnection[T signer.Signature](conn WebsocketConnection, assets *OutgoingWebsocketConnectionAssets[T], logger zerolog.Logger) *OutgoingWebsocketConnection[T] {
 	return &OutgoingWebsocketConnection[T]{
-		assetIds:                 assetIds,
+		WebsocketConnection:      conn,
+		assets:                   assets,
 		signedPriceUpdateBatchCh: make(chan SignedPriceUpdateBatch[T], 4096),
 		logger:                   logger,
 	}
-}
-
-func (owc *OutgoingWebsocketConnection[T]) SetWebsocketConn(conn WebsocketConnection) {
-	owc.WebsocketConnection = conn
-}
-
-func (owc *OutgoingWebsocketConnection[T]) UpdateAssets(assetIds map[AssetId]struct{}) {
-	owc.assetIdsLock.Lock()
-	owc.assetIds = assetIds
-	owc.assetIdsLock.Unlock()
 }
 
 func (owc *OutgoingWebsocketConnection[T]) Remove() {
@@ -225,21 +250,7 @@ func (owc *OutgoingWebsocketConnection[T]) Writer() {
 				return
 			}
 
-			filteredPriceUpdates := make(SignedPriceUpdateBatch[T])
-			owc.assetIdsLock.RLock()
-			_, allAssets := owc.assetIds[WildcardSubscriptionAsset]
-			if allAssets {
-				filteredPriceUpdates = signedPriceUpdateBatch
-			} else {
-				for asset, signedPriceUpdate := range signedPriceUpdateBatch {
-					_, exists := owc.assetIds[asset]
-					if exists {
-						filteredPriceUpdates[asset] = signedPriceUpdate
-					}
-				}
-			}
-			owc.assetIdsLock.RUnlock()
-
+			filteredPriceUpdates := owc.assets.filterSignedPriceUpdateBatch(signedPriceUpdateBatch)
 			if len(filteredPriceUpdates) > 0 {
 				err = SendWebsocketMsg[SignedPriceUpdateBatch[T]](owc.conn, "signed_prices", filteredPriceUpdates, "", "", logger)
 				if err != nil {

--- a/apps/lib/publisher_agent/websocket.go
+++ b/apps/lib/publisher_agent/websocket.go
@@ -252,7 +252,7 @@ func (owc *OutgoingWebsocketConnection[T]) Writer() {
 
 			filteredPriceUpdates := owc.assets.filterSignedPriceUpdateBatch(signedPriceUpdateBatch)
 			if len(filteredPriceUpdates) > 0 {
-				err = SendWebsocketMsg[SignedPriceUpdateBatch[T]](owc.conn, "signed_prices", filteredPriceUpdates, "", "", logger)
+				err = SendWebsocketMsg(owc.conn, "signed_prices", filteredPriceUpdates, "", "", logger)
 				if err != nil {
 					logger.Warn().Err(err).Msg("failed to send signed prices")
 				}
@@ -329,7 +329,7 @@ func SendWebsocketMsg[T any](conn *websocket.Conn, msgType string, data T, trace
 		Data:    data,
 	}
 
-	return sendWebsocketResponse[WebsocketMessage[T]](conn, msg, logger, OutgoingWriteTimeout)
+	return sendWebsocketResponse(conn, msg, logger, OutgoingWriteTimeout)
 }
 
 func sendWebsocketResponse[T any](conn *websocket.Conn, msg T, logger zerolog.Logger, writeTimeout time.Duration) error {

--- a/apps/lib/publisher_agent/websocket.go
+++ b/apps/lib/publisher_agent/websocket.go
@@ -237,7 +237,7 @@ func (owc *OutgoingWebsocketConnection[T]) Writer() {
 			}
 			owc.assetIdsLock.RUnlock()
 
-			if len(signedPriceUpdateBatch) > 0 {
+			if len(filteredPriceUpdates) > 0 {
 				err = SendWebsocketMsg[SignedPriceUpdateBatch[T]](owc.conn, "signed_prices", filteredPriceUpdates, "", "", logger)
 				if err != nil {
 					logger.Warn().Err(err).Msg("failed to send signed prices")

--- a/apps/lib/publisher_agent/websocket.go
+++ b/apps/lib/publisher_agent/websocket.go
@@ -180,13 +180,16 @@ type OutgoingWebsocketConnection[T signer.Signature] struct {
 	signedPriceUpdateBatchCh chan SignedPriceUpdateBatch[T]
 }
 
-func NewOutgoingWebsocketConnection[T signer.Signature](conn WebsocketConnection, assetIds map[AssetId]struct{}, logger zerolog.Logger) *OutgoingWebsocketConnection[T] {
+func NewOutgoingWebsocketConnection[T signer.Signature](assetIds map[AssetId]struct{}, logger zerolog.Logger) *OutgoingWebsocketConnection[T] {
 	return &OutgoingWebsocketConnection[T]{
-		WebsocketConnection:      conn,
 		assetIds:                 assetIds,
 		signedPriceUpdateBatchCh: make(chan SignedPriceUpdateBatch[T], 4096),
 		logger:                   logger,
 	}
+}
+
+func (owc *OutgoingWebsocketConnection[T]) SetWebsocketConn(conn WebsocketConnection) {
+	owc.WebsocketConnection = conn
 }
 
 func (owc *OutgoingWebsocketConnection[T]) UpdateAssets(assetIds map[AssetId]struct{}) {


### PR DESCRIPTION
# Problem
When we removed an asset from the whiteslist for a publisher and the publisher agent received an update for an asset which was not whitelisted, we observed:
1. The publisher agent would sometimes send empty messages to the aggregator, which is treated as an invalid message and caused the aggregator to disconnect the publisher repeatedly
2. When disconnected, the existing `RunOutgoingConnection` goroutine would restart with the originally configured asset list, even though the asset list had changed in the registry


# Testing
- [x] adding a new asset to the whitelist is respected for a running agent
- [x] removing an asset from the whitelist is respected for a running agent
- [x] the agent reconnects successfully after an incoming websocket disconnect
- [x] the agent reconnect successfully after an outgoing websocket disconnect 