### PR TITLE
Fuel audit changes

### DIFF
--- a/contracts/fuel/contracts/stork/src/main.sw
+++ b/contracts/fuel/contracts/stork/src/main.sw
@@ -267,6 +267,10 @@ impl Stork for Contract {
         }
 
         let required_fee = get_total_fee(num_updates);
+        if (std::call_frames::msg_asset_id() != AssetId::base()) {
+            log(StorkError::InsufficientFee);
+            revert(0)
+        }
         if (std::context::msg_amount() < required_fee) {
             log(StorkError::InsufficientFee);
             revert(0);

--- a/contracts/fuel/contracts/stork/src/main.sw
+++ b/contracts/fuel/contracts/stork/src/main.sw
@@ -128,7 +128,9 @@ fn only_owner() {
         standards::src5::State::Initialized(owner) => {
             require(msg_sender().unwrap() == owner, "Only Owner");
         },
-        standards::src5::State::Revoked => {}
+        standards::src5::State::Revoked => {
+            revert(0);
+        }
     }
 }
 

--- a/contracts/fuel/contracts/stork/src/main.sw
+++ b/contracts/fuel/contracts/stork/src/main.sw
@@ -39,12 +39,12 @@ struct State {
 storage {
     /// The owner in storage.
     owner: standards::src5::State = standards::src5::State::Uninitialized,
+    proposed_owner: Identity = Identity::Address(Address::zero()),
     initialized: bool = false,
     initializing: bool = false,
     state: State = State {
         stork_public_key: EvmAddress::zero(),
         single_update_fee_in_wei: 0,
-        // valid_time_period_seconds: 0,
         latest_canonical_temporal_numeric_values: StorageMap::<b256, TemporalNumericValue> {},
     },
 }
@@ -174,6 +174,12 @@ abi Stork {
 
     #[storage(read, write)]
     fn update_stork_public_key(stork_public_key: EvmAddress);
+
+    #[storage(read, write)]
+    fn propose_owner(new_owner: Address);
+
+    #[storage(read, write)]
+    fn accept_ownership();
 }
 
 impl Stork for Contract {
@@ -306,6 +312,19 @@ impl Stork for Contract {
     #[storage(read, write)]
     fn update_stork_public_key(stork_public_key: EvmAddress) {
         _update_stork_public_key(stork_public_key)
+    }
+
+    #[storage(read, write)]
+    fn propose_owner(new_owner: Address) {
+        only_owner();
+        storage.proposed_owner.write(Identity::Address(new_owner));
+    }
+
+    #[storage(read, write)]
+    fn accept_ownership() {
+        require(storage.proposed_owner.read() == msg_sender().unwrap(), "Only proposed owner can accept ownership");
+        storage.owner.write(standards::src5::State::Initialized(storage.proposed_owner.read()));
+        storage.proposed_owner.write(Identity::Address(Address::zero()));
     }
 }
 

--- a/contracts/fuel/contracts/stork/src/verify.sw
+++ b/contracts/fuel/contracts/stork/src/verify.sw
@@ -90,6 +90,13 @@ fn get_eth_signed_message_hash(msg_hash: b256) -> Message {
 }
 
 fn try_get_rsv_signature_from_parts(r: b256, s: b256, v: u8) -> Option<Secp256k1> {
+
+    // EIP-2 signature malleability compliance (https://eips.ethereum.org/EIPS/eip-2)
+    require( 
+        s <= 
+b256::from(0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0), 
+        "InvalidSignature" 
+    );
     // make most significant bit of s 0 or 1 depending on v
     match v {
         27 => {

--- a/contracts/fuel/contracts/stork/tests/harness.rs
+++ b/contracts/fuel/contracts/stork/tests/harness.rs
@@ -564,6 +564,14 @@ async fn test_ownership_transfer_owner() {
     
     // Verify the fee was actually updated
     assert_eq!(stork_instance.methods().single_update_fee_in_wei().call().await.unwrap().value, new_fee);
+
+    // Verify old owner can no longer call only_owner() guarded functions
+    let newer_fee = 10;
+    let res = stork_instance.clone().with_account(stork_owner).methods().update_single_update_fee_in_wei(newer_fee).call().await;
+    assert!(res.is_err());
+
+    // Verify the fee was not updated
+    assert_eq!(stork_instance.methods().single_update_fee_in_wei().call().await.unwrap().value, new_fee);
 }
 
 #[tokio::test]

--- a/contracts/fuel/contracts/stork/tests/harness.rs
+++ b/contracts/fuel/contracts/stork/tests/harness.rs
@@ -1,21 +1,16 @@
 use fuels::{
-    prelude::*, programs::responses::CallResponse, types::{
-        Bits256,
-        EvmAddress, Identity,
-    }
+    prelude::*,
+    programs::responses::CallResponse,
+    types::{Bits256, EvmAddress, Identity},
 };
 
 const CUSTOM_ASSET_ID: [u8; 32] = [1u8; 32];
 
 // Load abi from json
-abigen!(Contract(
-    name = "Stork",
-    abi = "out/debug/stork-abi.json"
-));
+abigen!(Contract(name = "Stork", abi = "out/debug/stork-abi.json"));
 
 // sets up the test environment, returns two wallets (first is the stork owner, second is not), the stork contract instance and its id
 async fn setup_tests() -> (WalletUnlocked, WalletUnlocked, Stork<WalletUnlocked>) {
-
     let base_asset_config = AssetConfig {
         id: AssetId::BASE,
         num_coins: 1,
@@ -29,10 +24,7 @@ async fn setup_tests() -> (WalletUnlocked, WalletUnlocked, Stork<WalletUnlocked>
     };
 
     let mut wallets = launch_custom_provider_and_get_wallets(
-        WalletsConfig::new_multiple_assets(
-            2,
-            vec![base_asset_config, custom_asset_config],
-        ),
+        WalletsConfig::new_multiple_assets(2, vec![base_asset_config, custom_asset_config]),
         None,
         None,
     )
@@ -48,31 +40,33 @@ async fn setup_tests() -> (WalletUnlocked, WalletUnlocked, Stork<WalletUnlocked>
 
 async fn get_contract_instance(wallet: WalletUnlocked) -> Stork<WalletUnlocked> {
     // Launch a local network and deploy the contract
-    
-    let id = Contract::load_from(
-        "./out/debug/stork.bin",
-        LoadConfiguration::default(),
-    )
-    .unwrap()
-    .deploy(&wallet, TxPolicies::default())
-    .await
-    .unwrap();
+
+    let id = Contract::load_from("./out/debug/stork.bin", LoadConfiguration::default())
+        .unwrap()
+        .deploy(&wallet, TxPolicies::default())
+        .await
+        .unwrap();
 
     let instance = Stork::new(id.clone(), wallet);
 
     instance
 }
 
-async fn initialize_stork_default(stork_instance: &Stork<WalletUnlocked>, stork_owner: WalletUnlocked) -> Result<CallResponse<()>> {
+async fn initialize_stork_default(
+    stork_instance: &Stork<WalletUnlocked>,
+    stork_owner: WalletUnlocked,
+) -> Result<CallResponse<()>> {
     // construct evm address
-    let stork_pub_key_bits = Bits256::from_hex_str("0x0000000000000000000000000a803F9b1CCe32e2773e0d2e98b37E0775cA5d44").unwrap();
+    let stork_pub_key_bits =
+        Bits256::from_hex_str("0x0000000000000000000000000a803F9b1CCe32e2773e0d2e98b37E0775cA5d44")
+            .unwrap();
     let stork_pub_key = EvmAddress::from(stork_pub_key_bits);
-    let fee = 1; 
-    stork_instance.methods().initialize(
-        stork_owner.address().into(),
-        stork_pub_key,
-        fee,
-    ).call().await
+    let fee = 1;
+    stork_instance
+        .methods()
+        .initialize(stork_owner.address().into(), stork_pub_key, fee)
+        .call()
+        .await
 }
 
 #[tokio::test]
@@ -80,19 +74,43 @@ async fn test_initialization() {
     let (stork_owner, _, stork_instance) = setup_tests().await;
 
     // construct evm address
-    let stork_pub_key_bits = Bits256::from_hex_str("0x0000000000000000000000000a803F9b1CCe32e2773e0d2e98b37E0775cA5d44").unwrap();
+    let stork_pub_key_bits =
+        Bits256::from_hex_str("0x0000000000000000000000000a803F9b1CCe32e2773e0d2e98b37E0775cA5d44")
+            .unwrap();
     let stork_pub_key = EvmAddress::from(stork_pub_key_bits);
     let fee = 1;
 
-    stork_instance.methods().initialize(
-        stork_owner.address().into(),
-        stork_pub_key,
-        fee,
-    ).call().await.unwrap();
+    stork_instance
+        .methods()
+        .initialize(stork_owner.address().into(), stork_pub_key, fee)
+        .call()
+        .await
+        .unwrap();
 
-    assert_eq!(stork_instance.methods().stork_public_key().call().await.unwrap().value, stork_pub_key);
-    assert_eq!(stork_instance.methods().single_update_fee_in_wei().call().await.unwrap().value, fee);
-    assert_eq!(stork_instance.methods().owner().call().await.unwrap().value, State::Initialized(stork_owner.address().into()));
+    assert_eq!(
+        stork_instance
+            .methods()
+            .stork_public_key()
+            .call()
+            .await
+            .unwrap()
+            .value,
+        stork_pub_key
+    );
+    assert_eq!(
+        stork_instance
+            .methods()
+            .single_update_fee_in_wei()
+            .call()
+            .await
+            .unwrap()
+            .value,
+        fee
+    );
+    assert_eq!(
+        stork_instance.methods().owner().call().await.unwrap().value,
+        State::Initialized(stork_owner.address().into())
+    );
 }
 
 #[tokio::test]
@@ -100,25 +118,49 @@ async fn test_no_duplicate_initialization() {
     let (stork_owner, _, stork_instance) = setup_tests().await;
 
     // construct evm address
-    let stork_pub_key_bits = Bits256::from_hex_str("0x0000000000000000000000000a803F9b1CCe32e2773e0d2e98b37E0775cA5d44").unwrap();
+    let stork_pub_key_bits =
+        Bits256::from_hex_str("0x0000000000000000000000000a803F9b1CCe32e2773e0d2e98b37E0775cA5d44")
+            .unwrap();
     let stork_pub_key = EvmAddress::from(stork_pub_key_bits);
     let fee = 1;
 
-    stork_instance.methods().initialize(
-        stork_owner.address().into(),
-        stork_pub_key,
-        fee,
-    ).call().await.unwrap();
+    stork_instance
+        .methods()
+        .initialize(stork_owner.address().into(), stork_pub_key, fee)
+        .call()
+        .await
+        .unwrap();
 
-    assert_eq!(stork_instance.methods().stork_public_key().call().await.unwrap().value, stork_pub_key);
-    assert_eq!(stork_instance.methods().single_update_fee_in_wei().call().await.unwrap().value, fee);
-    assert_eq!(stork_instance.methods().owner().call().await.unwrap().value, State::Initialized(stork_owner.address().into()));
+    assert_eq!(
+        stork_instance
+            .methods()
+            .stork_public_key()
+            .call()
+            .await
+            .unwrap()
+            .value,
+        stork_pub_key
+    );
+    assert_eq!(
+        stork_instance
+            .methods()
+            .single_update_fee_in_wei()
+            .call()
+            .await
+            .unwrap()
+            .value,
+        fee
+    );
+    assert_eq!(
+        stork_instance.methods().owner().call().await.unwrap().value,
+        State::Initialized(stork_owner.address().into())
+    );
 
-    let res = stork_instance.methods().initialize(
-        stork_owner.address().into(),
-        stork_pub_key,
-        fee,
-    ).call().await;
+    let res = stork_instance
+        .methods()
+        .initialize(stork_owner.address().into(), stork_pub_key, fee)
+        .call()
+        .await;
     assert!(res.is_err());
 }
 
@@ -126,69 +168,159 @@ async fn test_no_duplicate_initialization() {
 async fn test_update_stork_public_key_owner() {
     let (stork_owner, _, stork_instance) = setup_tests().await;
 
-    initialize_stork_default(&stork_instance, stork_owner).await.unwrap();
+    initialize_stork_default(&stork_instance, stork_owner)
+        .await
+        .unwrap();
 
     // construct new public key
-    let stork_pub_key_bits = Bits256::from_hex_str("0x0000000000000000000000000a803F9b1CCe32e2773e0d2e98b37E0775cA5d45").unwrap();
+    let stork_pub_key_bits =
+        Bits256::from_hex_str("0x0000000000000000000000000a803F9b1CCe32e2773e0d2e98b37E0775cA5d45")
+            .unwrap();
     let stork_pub_key = EvmAddress::from(stork_pub_key_bits);
 
-    stork_instance.methods().update_stork_public_key(stork_pub_key).call().await.unwrap();
+    stork_instance
+        .methods()
+        .update_stork_public_key(stork_pub_key)
+        .call()
+        .await
+        .unwrap();
 
-    assert_eq!(stork_instance.methods().stork_public_key().call().await.unwrap().value, stork_pub_key);
+    assert_eq!(
+        stork_instance
+            .methods()
+            .stork_public_key()
+            .call()
+            .await
+            .unwrap()
+            .value,
+        stork_pub_key
+    );
 }
 
 #[tokio::test]
 async fn test_update_stork_public_key_not_owner() {
     let (stork_owner, not_stork_owner, stork_instance) = setup_tests().await;
 
-    initialize_stork_default(&stork_instance, stork_owner).await.unwrap();
+    initialize_stork_default(&stork_instance, stork_owner)
+        .await
+        .unwrap();
 
     // get current public key
-    let current_stork_pub_key = stork_instance.methods().stork_public_key().call().await.unwrap().value;
+    let current_stork_pub_key = stork_instance
+        .methods()
+        .stork_public_key()
+        .call()
+        .await
+        .unwrap()
+        .value;
 
     // construct new public key
-    let stork_pub_key_bits = Bits256::from_hex_str("0x0000000000000000000000000a803F9b1CCe32e2773e0d2e98b37E0775cA5d45").unwrap();
+    let stork_pub_key_bits =
+        Bits256::from_hex_str("0x0000000000000000000000000a803F9b1CCe32e2773e0d2e98b37E0775cA5d45")
+            .unwrap();
     let stork_pub_key = EvmAddress::from(stork_pub_key_bits);
 
-    let res = stork_instance.clone().with_account(not_stork_owner).methods().update_stork_public_key(stork_pub_key).call().await;
+    let res = stork_instance
+        .clone()
+        .with_account(not_stork_owner)
+        .methods()
+        .update_stork_public_key(stork_pub_key)
+        .call()
+        .await;
     assert!(res.is_err());
-    assert_eq!(stork_instance.methods().stork_public_key().call().await.unwrap().value, current_stork_pub_key);
+    assert_eq!(
+        stork_instance
+            .methods()
+            .stork_public_key()
+            .call()
+            .await
+            .unwrap()
+            .value,
+        current_stork_pub_key
+    );
 }
 
 #[tokio::test]
 async fn test_update_stork_single_update_fee_in_wei_owner() {
     let (stork_owner, _, stork_instance) = setup_tests().await;
 
-    initialize_stork_default(&stork_instance, stork_owner).await.unwrap();
+    initialize_stork_default(&stork_instance, stork_owner)
+        .await
+        .unwrap();
 
     let new_fee = 2;
-    stork_instance.methods().update_single_update_fee_in_wei(new_fee).call().await.unwrap();
+    stork_instance
+        .methods()
+        .update_single_update_fee_in_wei(new_fee)
+        .call()
+        .await
+        .unwrap();
 
-    assert_eq!(stork_instance.methods().single_update_fee_in_wei().call().await.unwrap().value, new_fee);
+    assert_eq!(
+        stork_instance
+            .methods()
+            .single_update_fee_in_wei()
+            .call()
+            .await
+            .unwrap()
+            .value,
+        new_fee
+    );
 }
 
 #[tokio::test]
 async fn test_update_stork_single_update_fee_in_wei_not_owner() {
     let (stork_owner, not_stork_owner, stork_instance) = setup_tests().await;
 
-    initialize_stork_default(&stork_instance, stork_owner).await.unwrap();
+    initialize_stork_default(&stork_instance, stork_owner)
+        .await
+        .unwrap();
 
     // get current fee
-    let current_fee = stork_instance.methods().single_update_fee_in_wei().call().await.unwrap().value;
+    let current_fee = stork_instance
+        .methods()
+        .single_update_fee_in_wei()
+        .call()
+        .await
+        .unwrap()
+        .value;
 
     let new_fee = 2;
-    let res = stork_instance.clone().with_account(not_stork_owner).methods().update_single_update_fee_in_wei(new_fee).call().await;
+    let res = stork_instance
+        .clone()
+        .with_account(not_stork_owner)
+        .methods()
+        .update_single_update_fee_in_wei(new_fee)
+        .call()
+        .await;
     assert!(res.is_err());
-    assert_eq!(stork_instance.methods().single_update_fee_in_wei().call().await.unwrap().value, current_fee);
+    assert_eq!(
+        stork_instance
+            .methods()
+            .single_update_fee_in_wei()
+            .call()
+            .await
+            .unwrap()
+            .value,
+        current_fee
+    );
 }
 
 #[tokio::test]
 async fn test_version() {
     let (stork_owner, _, stork_instance) = setup_tests().await;
 
-    initialize_stork_default(&stork_instance, stork_owner).await.unwrap();
+    initialize_stork_default(&stork_instance, stork_owner)
+        .await
+        .unwrap();
 
-    let version = stork_instance.methods().version().call().await.unwrap().value;
+    let version = stork_instance
+        .methods()
+        .version()
+        .call()
+        .await
+        .unwrap()
+        .value;
     assert_eq!(version, "1.0.0");
 }
 
@@ -196,26 +328,57 @@ async fn test_version() {
 async fn test_verify_stork_signature_v1_valid() {
     let (stork_owner, _, stork_instance) = setup_tests().await;
 
-    initialize_stork_default(&stork_instance, stork_owner).await.unwrap();
+    initialize_stork_default(&stork_instance, stork_owner)
+        .await
+        .unwrap();
 
     // construct evm address
-    let stork_pub_key_bits = Bits256::from_hex_str("0x0000000000000000000000000a803F9b1CCe32e2773e0d2e98b37E0775cA5d44").unwrap();
+    let stork_pub_key_bits =
+        Bits256::from_hex_str("0x0000000000000000000000000a803F9b1CCe32e2773e0d2e98b37E0775cA5d44")
+            .unwrap();
     let stork_pub_key = EvmAddress::from(stork_pub_key_bits);
 
     let quantized_value_u128 = 62507457175499998000000u128;
-    let indent = 1u128 << 127;  
+    let indent = 1u128 << 127;
     let value_with_indent = quantized_value_u128 + indent;
-    let quantized_value = I128 { underlying: value_with_indent };
+    let quantized_value = I128 {
+        underlying: value_with_indent,
+    };
 
-    let id = Bits256::from_hex_str("0x7404e3d104ea7841c3d9e6fd20adfe99b4ad586bc08d8f3bd3afef894cf184de").unwrap();
+    let id =
+        Bits256::from_hex_str("0x7404e3d104ea7841c3d9e6fd20adfe99b4ad586bc08d8f3bd3afef894cf184de")
+            .unwrap();
     let recv_time = 1722632569208762117;
-    let publisher_merkle_root = Bits256::from_hex_str("0xe5ff773b0316059c04aa157898766731017610dcbeede7d7f169bfeaab7cc318").unwrap();
-    let value_compute_alg_hash = Bits256::from_hex_str("0x9be7e9f9ed459417d96112a7467bd0b27575a2c7847195c68f805b70ce1795ba").unwrap();
-    let r = Bits256::from_hex_str("0xb9b3c9f80a355bd0cd6f609fff4a4b15fa4e3b4632adabb74c020f5bcd240741").unwrap();
-    let s = Bits256::from_hex_str("0x16fab526529ac795108d201832cff8c2d2b1c710da6711fe9f7ab288a7149758").unwrap();
+    let publisher_merkle_root =
+        Bits256::from_hex_str("0xe5ff773b0316059c04aa157898766731017610dcbeede7d7f169bfeaab7cc318")
+            .unwrap();
+    let value_compute_alg_hash =
+        Bits256::from_hex_str("0x9be7e9f9ed459417d96112a7467bd0b27575a2c7847195c68f805b70ce1795ba")
+            .unwrap();
+    let r =
+        Bits256::from_hex_str("0xb9b3c9f80a355bd0cd6f609fff4a4b15fa4e3b4632adabb74c020f5bcd240741")
+            .unwrap();
+    let s =
+        Bits256::from_hex_str("0x16fab526529ac795108d201832cff8c2d2b1c710da6711fe9f7ab288a7149758")
+            .unwrap();
     let v = 28;
 
-    let result = stork_instance.methods().verify_stork_signature_v1(stork_pub_key, id, recv_time, quantized_value, publisher_merkle_root, value_compute_alg_hash, r, s, v).call().await.unwrap();
+    let result = stork_instance
+        .methods()
+        .verify_stork_signature_v1(
+            stork_pub_key,
+            id,
+            recv_time,
+            quantized_value,
+            publisher_merkle_root,
+            value_compute_alg_hash,
+            r,
+            s,
+            v,
+        )
+        .call()
+        .await
+        .unwrap();
     println!("result: {:?}", result);
     assert!(result.value);
 }
@@ -224,27 +387,58 @@ async fn test_verify_stork_signature_v1_valid() {
 async fn test_verify_stork_signature_v1_invalid() {
     let (stork_owner, _, stork_instance) = setup_tests().await;
 
-    initialize_stork_default(&stork_instance, stork_owner).await.unwrap();
+    initialize_stork_default(&stork_instance, stork_owner)
+        .await
+        .unwrap();
 
     // construct evm address
-    let stork_pub_key_bits = Bits256::from_hex_str("0x0000000000000000000000000a803F9b1CCe32e2773e0d2e98b37E0775cA5d44").unwrap();
+    let stork_pub_key_bits =
+        Bits256::from_hex_str("0x0000000000000000000000000a803F9b1CCe32e2773e0d2e98b37E0775cA5d44")
+            .unwrap();
     let stork_pub_key = EvmAddress::from(stork_pub_key_bits);
 
     // construct quantized value - exactly matching the contract test - just a little too high
     let quantized_value_u128 = 62507457175499999000000u128;
-    let indent = 1u128 << 127;  
+    let indent = 1u128 << 127;
     let value_with_indent = quantized_value_u128 + indent;
-    let quantized_value = I128 { underlying: value_with_indent };
+    let quantized_value = I128 {
+        underlying: value_with_indent,
+    };
 
-    let id = Bits256::from_hex_str("0x7404e3d104ea7841c3d9e6fd20adfe99b4ad586bc08d8f3bd3afef894cf184de").unwrap();
+    let id =
+        Bits256::from_hex_str("0x7404e3d104ea7841c3d9e6fd20adfe99b4ad586bc08d8f3bd3afef894cf184de")
+            .unwrap();
     let recv_time = 1722632569208762117;
-    let publisher_merkle_root = Bits256::from_hex_str("0xe5ff773b0316059c04aa157898766731017610dcbeede7d7f169bfeaab7cc318").unwrap();
-    let value_compute_alg_hash = Bits256::from_hex_str("0x9be7e9f9ed459417d96112a7467bd0b27575a2c7847195c68f805b70ce1795ba").unwrap();
-    let r = Bits256::from_hex_str("0xb9b3c9f80a355bd0cd6f609fff4a4b15fa4e3b4632adabb74c020f5bcd240741").unwrap();
-    let s = Bits256::from_hex_str("0x16fab526529ac795108d201832cff8c2d2b1c710da6711fe9f7ab288a7149758").unwrap();
+    let publisher_merkle_root =
+        Bits256::from_hex_str("0xe5ff773b0316059c04aa157898766731017610dcbeede7d7f169bfeaab7cc318")
+            .unwrap();
+    let value_compute_alg_hash =
+        Bits256::from_hex_str("0x9be7e9f9ed459417d96112a7467bd0b27575a2c7847195c68f805b70ce1795ba")
+            .unwrap();
+    let r =
+        Bits256::from_hex_str("0xb9b3c9f80a355bd0cd6f609fff4a4b15fa4e3b4632adabb74c020f5bcd240741")
+            .unwrap();
+    let s =
+        Bits256::from_hex_str("0x16fab526529ac795108d201832cff8c2d2b1c710da6711fe9f7ab288a7149758")
+            .unwrap();
     let v = 28;
 
-    let result = stork_instance.methods().verify_stork_signature_v1(stork_pub_key, id, recv_time, quantized_value, publisher_merkle_root, value_compute_alg_hash, r, s, v).call().await.unwrap();
+    let result = stork_instance
+        .methods()
+        .verify_stork_signature_v1(
+            stork_pub_key,
+            id,
+            recv_time,
+            quantized_value,
+            publisher_merkle_root,
+            value_compute_alg_hash,
+            r,
+            s,
+            v,
+        )
+        .call()
+        .await
+        .unwrap();
     assert!(!result.value);
 }
 
@@ -252,20 +446,34 @@ async fn test_verify_stork_signature_v1_invalid() {
 async fn test_update_temporal_numeric_value_v1_valid() {
     let (stork_owner, not_stork_owner, stork_instance) = setup_tests().await;
 
-    initialize_stork_default(&stork_instance, stork_owner).await.unwrap();
+    initialize_stork_default(&stork_instance, stork_owner)
+        .await
+        .unwrap();
 
     // construct quantized value - exactly matching the contract test
     let quantized_value_u128 = 62507457175499998000000u128;
-    let indent = 1u128 << 127;  
+    let indent = 1u128 << 127;
     let value_with_indent = quantized_value_u128 + indent;
-    let quantized_value = I128 { underlying: value_with_indent };
-    
-    let id = Bits256::from_hex_str("0x7404e3d104ea7841c3d9e6fd20adfe99b4ad586bc08d8f3bd3afef894cf184de").unwrap();
+    let quantized_value = I128 {
+        underlying: value_with_indent,
+    };
+
+    let id =
+        Bits256::from_hex_str("0x7404e3d104ea7841c3d9e6fd20adfe99b4ad586bc08d8f3bd3afef894cf184de")
+            .unwrap();
     let recv_time = 1722632569208762117;
-    let publisher_merkle_root = Bits256::from_hex_str("0xe5ff773b0316059c04aa157898766731017610dcbeede7d7f169bfeaab7cc318").unwrap();
-    let value_compute_alg_hash = Bits256::from_hex_str("0x9be7e9f9ed459417d96112a7467bd0b27575a2c7847195c68f805b70ce1795ba").unwrap();
-    let r = Bits256::from_hex_str("0xb9b3c9f80a355bd0cd6f609fff4a4b15fa4e3b4632adabb74c020f5bcd240741").unwrap();
-    let s = Bits256::from_hex_str("0x16fab526529ac795108d201832cff8c2d2b1c710da6711fe9f7ab288a7149758").unwrap();
+    let publisher_merkle_root =
+        Bits256::from_hex_str("0xe5ff773b0316059c04aa157898766731017610dcbeede7d7f169bfeaab7cc318")
+            .unwrap();
+    let value_compute_alg_hash =
+        Bits256::from_hex_str("0x9be7e9f9ed459417d96112a7467bd0b27575a2c7847195c68f805b70ce1795ba")
+            .unwrap();
+    let r =
+        Bits256::from_hex_str("0xb9b3c9f80a355bd0cd6f609fff4a4b15fa4e3b4632adabb74c020f5bcd240741")
+            .unwrap();
+    let s =
+        Bits256::from_hex_str("0x16fab526529ac795108d201832cff8c2d2b1c710da6711fe9f7ab288a7149758")
+            .unwrap();
     let v = 28;
 
     let temporal_numeric_value = TemporalNumericValue {
@@ -286,22 +494,36 @@ async fn test_update_temporal_numeric_value_v1_valid() {
     let temporal_numeric_value_input_vec = vec![temporal_numeric_value_input];
 
     // Get the required fee
-    let fee = stork_instance.methods().get_update_fee_v1(temporal_numeric_value_input_vec.clone()).call().await.unwrap().value;
+    let fee = stork_instance
+        .methods()
+        .get_update_fee_v1(temporal_numeric_value_input_vec.clone())
+        .call()
+        .await
+        .unwrap()
+        .value;
 
     let tx_policies = TxPolicies::default();
     let call_params = CallParameters::default().with_amount(fee);
-    stork_instance.clone()
+    stork_instance
+        .clone()
         .with_account(not_stork_owner)
         .methods()
         .update_temporal_numeric_values_v1(temporal_numeric_value_input_vec)
         .with_tx_policies(tx_policies)
-        .call_params(call_params).unwrap()
+        .call_params(call_params)
+        .unwrap()
         .call()
-        .await.unwrap();
-
+        .await
+        .unwrap();
 
     // get the temporal numeric value
-    let temporal_numeric_value = stork_instance.methods().get_temporal_numeric_value_unchecked_v1(id).call().await.unwrap().value;
+    let temporal_numeric_value = stork_instance
+        .methods()
+        .get_temporal_numeric_value_unchecked_v1(id)
+        .call()
+        .await
+        .unwrap()
+        .value;
     assert_eq!(temporal_numeric_value.timestamp_ns, recv_time);
     assert_eq!(temporal_numeric_value.quantized_value, quantized_value);
 }
@@ -310,19 +532,33 @@ async fn test_update_temporal_numeric_value_v1_valid() {
 async fn test_update_temporal_numeric_value_v1_negative() {
     let (stork_owner, not_stork_owner, stork_instance) = setup_tests().await;
 
-    initialize_stork_default(&stork_instance, stork_owner).await.unwrap();
-    
+    initialize_stork_default(&stork_instance, stork_owner)
+        .await
+        .unwrap();
+
     // construct quantized value
     let quantized_value_u128 = 3020199000000u128;
-    let indent = 1u128 << 127;  
-    let quantized_value = I128 { underlying: indent - quantized_value_u128 };
+    let indent = 1u128 << 127;
+    let quantized_value = I128 {
+        underlying: indent - quantized_value_u128,
+    };
 
-    let id = Bits256::from_hex_str("0x281a649a11eb25eca04f0025c15e99264a056229e722735c7d6c55fef649dfbf").unwrap();
+    let id =
+        Bits256::from_hex_str("0x281a649a11eb25eca04f0025c15e99264a056229e722735c7d6c55fef649dfbf")
+            .unwrap();
     let recv_time = 1750794968021348308u64;
-    let publisher_merkle_root = Bits256::from_hex_str("0x5ea4136e8064520a3311961f3f7030dfbc0b96652f46a473e79f2a019b3cd878").unwrap();
-    let value_compute_alg_hash = Bits256::from_hex_str("0x9be7e9f9ed459417d96112a7467bd0b27575a2c7847195c68f805b70ce1795ba").unwrap();
-    let r = Bits256::from_hex_str("0x14c36cf7272689cec0335efdc5f82dc2d4b1aceb8d2320d3245e4593df32e696").unwrap();
-    let s = Bits256::from_hex_str("0x79ab437ecd56dc9fcf850f192328840f7f47d5df57cb939d99146b33014c39f0").unwrap();
+    let publisher_merkle_root =
+        Bits256::from_hex_str("0x5ea4136e8064520a3311961f3f7030dfbc0b96652f46a473e79f2a019b3cd878")
+            .unwrap();
+    let value_compute_alg_hash =
+        Bits256::from_hex_str("0x9be7e9f9ed459417d96112a7467bd0b27575a2c7847195c68f805b70ce1795ba")
+            .unwrap();
+    let r =
+        Bits256::from_hex_str("0x14c36cf7272689cec0335efdc5f82dc2d4b1aceb8d2320d3245e4593df32e696")
+            .unwrap();
+    let s =
+        Bits256::from_hex_str("0x79ab437ecd56dc9fcf850f192328840f7f47d5df57cb939d99146b33014c39f0")
+            .unwrap();
     let v = 27;
 
     let temporal_numeric_value = TemporalNumericValue {
@@ -343,27 +579,49 @@ async fn test_update_temporal_numeric_value_v1_negative() {
     let temporal_numeric_value_input_vec = vec![temporal_numeric_value_input];
 
     // set public key to dev key
-    let stork_pub_key_bits = Bits256::from_hex_str("0x0000000000000000000000003db9E960ECfCcb11969509FAB000c0c96DC51830").unwrap();
+    let stork_pub_key_bits =
+        Bits256::from_hex_str("0x0000000000000000000000003db9E960ECfCcb11969509FAB000c0c96DC51830")
+            .unwrap();
     let stork_pub_key = EvmAddress::from(stork_pub_key_bits);
-    stork_instance.methods().update_stork_public_key(stork_pub_key).call().await.unwrap();
+    stork_instance
+        .methods()
+        .update_stork_public_key(stork_pub_key)
+        .call()
+        .await
+        .unwrap();
 
     // Get the required fee
-    let fee = stork_instance.methods().get_update_fee_v1(temporal_numeric_value_input_vec.clone()).call().await.unwrap().value;
+    let fee = stork_instance
+        .methods()
+        .get_update_fee_v1(temporal_numeric_value_input_vec.clone())
+        .call()
+        .await
+        .unwrap()
+        .value;
 
     let tx_policies = TxPolicies::default();
     let call_params = CallParameters::default().with_amount(fee);
 
-    stork_instance.clone()
+    stork_instance
+        .clone()
         .with_account(not_stork_owner)
         .methods()
         .update_temporal_numeric_values_v1(temporal_numeric_value_input_vec)
         .with_tx_policies(tx_policies)
-        .call_params(call_params).unwrap()
+        .call_params(call_params)
+        .unwrap()
         .call()
-        .await.unwrap();
+        .await
+        .unwrap();
 
     // get the temporal numeric value
-    let temporal_numeric_value = stork_instance.methods().get_temporal_numeric_value_unchecked_v1(id).call().await.unwrap().value;
+    let temporal_numeric_value = stork_instance
+        .methods()
+        .get_temporal_numeric_value_unchecked_v1(id)
+        .call()
+        .await
+        .unwrap()
+        .value;
     assert_eq!(temporal_numeric_value.timestamp_ns, recv_time);
     assert_eq!(temporal_numeric_value.quantized_value, quantized_value);
 }
@@ -372,20 +630,34 @@ async fn test_update_temporal_numeric_value_v1_negative() {
 async fn test_update_temporal_numeric_value_v1_invalid() {
     let (stork_owner, not_stork_owner, stork_instance) = setup_tests().await;
 
-    initialize_stork_default(&stork_instance, stork_owner).await.unwrap();
+    initialize_stork_default(&stork_instance, stork_owner)
+        .await
+        .unwrap();
 
     // construct quantized value - just a little too high
     let quantized_value_u128 = 62507457175499998000001u128;
-    let indent = 1u128 << 127;  
+    let indent = 1u128 << 127;
     let value_with_indent = quantized_value_u128 + indent;
-    let quantized_value = I128 { underlying: value_with_indent };
-    
-    let id = Bits256::from_hex_str("0x7404e3d104ea7841c3d9e6fd20adfe99b4ad586bc08d8f3bd3afef894cf184de").unwrap();
+    let quantized_value = I128 {
+        underlying: value_with_indent,
+    };
+
+    let id =
+        Bits256::from_hex_str("0x7404e3d104ea7841c3d9e6fd20adfe99b4ad586bc08d8f3bd3afef894cf184de")
+            .unwrap();
     let recv_time = 1722632569208762117;
-    let publisher_merkle_root = Bits256::from_hex_str("0xe5ff773b0316059c04aa157898766731017610dcbeede7d7f169bfeaab7cc318").unwrap();
-    let value_compute_alg_hash = Bits256::from_hex_str("0x9be7e9f9ed459417d96112a7467bd0b27575a2c7847195c68f805b70ce1795ba").unwrap();
-    let r = Bits256::from_hex_str("0xb9b3c9f80a355bd0cd6f609fff4a4b15fa4e3b4632adabb74c020f5bcd240741").unwrap();
-    let s = Bits256::from_hex_str("0x16fab526529ac795108d201832cff8c2d2b1c710da6711fe9f7ab288a7149758").unwrap();
+    let publisher_merkle_root =
+        Bits256::from_hex_str("0xe5ff773b0316059c04aa157898766731017610dcbeede7d7f169bfeaab7cc318")
+            .unwrap();
+    let value_compute_alg_hash =
+        Bits256::from_hex_str("0x9be7e9f9ed459417d96112a7467bd0b27575a2c7847195c68f805b70ce1795ba")
+            .unwrap();
+    let r =
+        Bits256::from_hex_str("0xb9b3c9f80a355bd0cd6f609fff4a4b15fa4e3b4632adabb74c020f5bcd240741")
+            .unwrap();
+    let s =
+        Bits256::from_hex_str("0x16fab526529ac795108d201832cff8c2d2b1c710da6711fe9f7ab288a7149758")
+            .unwrap();
     let v = 28;
 
     let temporal_numeric_value = TemporalNumericValue {
@@ -406,18 +678,25 @@ async fn test_update_temporal_numeric_value_v1_invalid() {
     let temporal_numeric_value_input_vec = vec![temporal_numeric_value_input];
 
     // Get the required fee
-    let fee = stork_instance.methods().get_update_fee_v1(temporal_numeric_value_input_vec.clone()).call().await.unwrap().value;
+    let fee = stork_instance
+        .methods()
+        .get_update_fee_v1(temporal_numeric_value_input_vec.clone())
+        .call()
+        .await
+        .unwrap()
+        .value;
 
     let tx_policies = TxPolicies::default();
     let call_params = CallParameters::default().with_amount(fee);
-    
+
     // This should fail since we modified the value
     let result = stork_instance
         .with_account(not_stork_owner)
         .methods()
         .update_temporal_numeric_values_v1(temporal_numeric_value_input_vec)
         .with_tx_policies(tx_policies)
-        .call_params(call_params).unwrap()
+        .call_params(call_params)
+        .unwrap()
         .call()
         .await;
 
@@ -440,16 +719,28 @@ async fn test_update_temporal_numeric_values_v1_insufficient_fee() {
 
     // Use valid signature values
     let quantized_value_u128 = 62507457175499998000000u128;
-    let indent = 1u128 << 127;  
+    let indent = 1u128 << 127;
     let value_with_indent = quantized_value_u128 + indent;
-    let quantized_value = I128 { underlying: value_with_indent };
-    
-    let id = Bits256::from_hex_str("0x7404e3d104ea7841c3d9e6fd20adfe99b4ad586bc08d8f3bd3afef894cf184de").unwrap();
+    let quantized_value = I128 {
+        underlying: value_with_indent,
+    };
+
+    let id =
+        Bits256::from_hex_str("0x7404e3d104ea7841c3d9e6fd20adfe99b4ad586bc08d8f3bd3afef894cf184de")
+            .unwrap();
     let recv_time = 1722632569208762117;
-    let publisher_merkle_root = Bits256::from_hex_str("0xe5ff773b0316059c04aa157898766731017610dcbeede7d7f169bfeaab7cc318").unwrap();
-    let value_compute_alg_hash = Bits256::from_hex_str("0x9be7e9f9ed459417d96112a7467bd0b27575a2c7847195c68f805b70ce1795ba").unwrap();
-    let r = Bits256::from_hex_str("0xb9b3c9f80a355bd0cd6f609fff4a4b15fa4e3b4632adabb74c020f5bcd240741").unwrap();
-    let s = Bits256::from_hex_str("0x16fab526529ac795108d201832cff8c2d2b1c710da6711fe9f7ab288a7149758").unwrap();
+    let publisher_merkle_root =
+        Bits256::from_hex_str("0xe5ff773b0316059c04aa157898766731017610dcbeede7d7f169bfeaab7cc318")
+            .unwrap();
+    let value_compute_alg_hash =
+        Bits256::from_hex_str("0x9be7e9f9ed459417d96112a7467bd0b27575a2c7847195c68f805b70ce1795ba")
+            .unwrap();
+    let r =
+        Bits256::from_hex_str("0xb9b3c9f80a355bd0cd6f609fff4a4b15fa4e3b4632adabb74c020f5bcd240741")
+            .unwrap();
+    let s =
+        Bits256::from_hex_str("0x16fab526529ac795108d201832cff8c2d2b1c710da6711fe9f7ab288a7149758")
+            .unwrap();
     let v = 28;
 
     let temporal_numeric_value = TemporalNumericValue {
@@ -472,13 +763,14 @@ async fn test_update_temporal_numeric_values_v1_insufficient_fee() {
     let tx_policies = TxPolicies::default();
     // Only send 1 when fee is 2
     let call_params = CallParameters::default().with_amount(1);
-    
+
     let result = stork_instance
         .with_account(not_stork_owner)
         .methods()
         .update_temporal_numeric_values_v1(temporal_numeric_value_input_vec)
         .with_tx_policies(tx_policies)
-        .call_params(call_params).unwrap()
+        .call_params(call_params)
+        .unwrap()
         .call()
         .await;
 
@@ -489,19 +781,33 @@ async fn test_update_temporal_numeric_values_v1_insufficient_fee() {
 async fn test_update_temporal_numeric_values_v1_wrong_asset() {
     let (stork_owner, not_stork_owner, stork_instance) = setup_tests().await;
 
-    initialize_stork_default(&stork_instance, stork_owner).await.unwrap();
+    initialize_stork_default(&stork_instance, stork_owner)
+        .await
+        .unwrap();
 
     let quantized_value_u128 = 62507457175499998000000u128;
-    let indent = 1u128 << 127;  
+    let indent = 1u128 << 127;
     let value_with_indent = quantized_value_u128 + indent;
-    let quantized_value = I128 { underlying: value_with_indent };
+    let quantized_value = I128 {
+        underlying: value_with_indent,
+    };
 
-    let id = Bits256::from_hex_str("0x7404e3d104ea7841c3d9e6fd20adfe99b4ad586bc08d8f3bd3afef894cf184de").unwrap();
+    let id =
+        Bits256::from_hex_str("0x7404e3d104ea7841c3d9e6fd20adfe99b4ad586bc08d8f3bd3afef894cf184de")
+            .unwrap();
     let recv_time = 1722632569208762117;
-    let publisher_merkle_root = Bits256::from_hex_str("0xe5ff773b0316059c04aa157898766731017610dcbeede7d7f169bfeaab7cc318").unwrap();
-    let value_compute_alg_hash = Bits256::from_hex_str("0x9be7e9f9ed459417d96112a7467bd0b27575a2c7847195c68f805b70ce1795ba").unwrap();
-    let r = Bits256::from_hex_str("0xb9b3c9f80a355bd0cd6f609fff4a4b15fa4e3b4632adabb74c020f5bcd240741").unwrap();
-    let s = Bits256::from_hex_str("0x16fab526529ac795108d201832cff8c2d2b1c710da6711fe9f7ab288a7149758").unwrap();
+    let publisher_merkle_root =
+        Bits256::from_hex_str("0xe5ff773b0316059c04aa157898766731017610dcbeede7d7f169bfeaab7cc318")
+            .unwrap();
+    let value_compute_alg_hash =
+        Bits256::from_hex_str("0x9be7e9f9ed459417d96112a7467bd0b27575a2c7847195c68f805b70ce1795ba")
+            .unwrap();
+    let r =
+        Bits256::from_hex_str("0xb9b3c9f80a355bd0cd6f609fff4a4b15fa4e3b4632adabb74c020f5bcd240741")
+            .unwrap();
+    let s =
+        Bits256::from_hex_str("0x16fab526529ac795108d201832cff8c2d2b1c710da6711fe9f7ab288a7149758")
+            .unwrap();
     let v = 28;
 
     let temporal_numeric_value = TemporalNumericValue {
@@ -524,16 +830,19 @@ async fn test_update_temporal_numeric_values_v1_wrong_asset() {
     let tx_policies = TxPolicies::default();
 
     let asset_id = AssetId::new(CUSTOM_ASSET_ID);
-    
+
     // Mint custom asset
-    let call_params = CallParameters::default().with_amount(1).with_asset_id(asset_id);
-    
+    let call_params = CallParameters::default()
+        .with_amount(1)
+        .with_asset_id(asset_id);
+
     let result = stork_instance
         .with_account(not_stork_owner)
         .methods()
         .update_temporal_numeric_values_v1(temporal_numeric_value_input_vec)
         .with_tx_policies(tx_policies)
-        .call_params(call_params).unwrap()
+        .call_params(call_params)
+        .unwrap()
         .call()
         .await;
 
@@ -544,46 +853,102 @@ async fn test_update_temporal_numeric_values_v1_wrong_asset() {
 async fn test_ownership_transfer_owner() {
     let (stork_owner, not_stork_owner, stork_instance) = setup_tests().await;
 
-    initialize_stork_default(&stork_instance, stork_owner.clone()).await.unwrap();
+    initialize_stork_default(&stork_instance, stork_owner.clone())
+        .await
+        .unwrap();
 
     let new_owner = not_stork_owner.address();
-    
+
     // Owner proposes new owner
-    stork_instance.methods().propose_owner(new_owner).call().await.unwrap();
+    stork_instance
+        .methods()
+        .propose_owner(new_owner)
+        .call()
+        .await
+        .unwrap();
 
     // Proposed owner accepts ownership
-    stork_instance.clone().with_account(not_stork_owner.clone()).methods().accept_ownership().call().await.unwrap();
+    stork_instance
+        .clone()
+        .with_account(not_stork_owner.clone())
+        .methods()
+        .accept_ownership()
+        .call()
+        .await
+        .unwrap();
 
     // Verify ownership has transferred by checking owner state
     let owner_state = stork_instance.methods().owner().call().await.unwrap().value;
-    assert_eq!(owner_state, State::Initialized(Identity::Address(new_owner.into())));
+    assert_eq!(
+        owner_state,
+        State::Initialized(Identity::Address(new_owner.into()))
+    );
 
     // Verify new owner can call only_owner() guarded functions
     let new_fee = 5;
-    stork_instance.clone().with_account(not_stork_owner).methods().update_single_update_fee_in_wei(new_fee).call().await.unwrap();
-    
+    stork_instance
+        .clone()
+        .with_account(not_stork_owner)
+        .methods()
+        .update_single_update_fee_in_wei(new_fee)
+        .call()
+        .await
+        .unwrap();
+
     // Verify the fee was actually updated
-    assert_eq!(stork_instance.methods().single_update_fee_in_wei().call().await.unwrap().value, new_fee);
+    assert_eq!(
+        stork_instance
+            .methods()
+            .single_update_fee_in_wei()
+            .call()
+            .await
+            .unwrap()
+            .value,
+        new_fee
+    );
 
     // Verify old owner can no longer call only_owner() guarded functions
     let newer_fee = 10;
-    let res = stork_instance.clone().with_account(stork_owner).methods().update_single_update_fee_in_wei(newer_fee).call().await;
+    let res = stork_instance
+        .clone()
+        .with_account(stork_owner)
+        .methods()
+        .update_single_update_fee_in_wei(newer_fee)
+        .call()
+        .await;
     assert!(res.is_err());
 
     // Verify the fee was not updated
-    assert_eq!(stork_instance.methods().single_update_fee_in_wei().call().await.unwrap().value, new_fee);
+    assert_eq!(
+        stork_instance
+            .methods()
+            .single_update_fee_in_wei()
+            .call()
+            .await
+            .unwrap()
+            .value,
+        new_fee
+    );
 }
 
 #[tokio::test]
 async fn test_ownership_transfer_not_owner() {
     let (stork_owner, not_stork_owner, stork_instance) = setup_tests().await;
 
-    initialize_stork_default(&stork_instance, stork_owner).await.unwrap();
+    initialize_stork_default(&stork_instance, stork_owner)
+        .await
+        .unwrap();
 
     let new_owner = not_stork_owner.address().clone();
-    
+
     // Non-owner tries to propose new owner - should fail
-    let res = stork_instance.clone().with_account(not_stork_owner).methods().propose_owner(new_owner).call().await;
+    let res = stork_instance
+        .clone()
+        .with_account(not_stork_owner)
+        .methods()
+        .propose_owner(new_owner)
+        .call()
+        .await;
     assert!(res.is_err());
 }
 
@@ -591,7 +956,9 @@ async fn test_ownership_transfer_not_owner() {
 async fn test_ownership_transfer_wrong_acceptor() {
     let (stork_owner, not_stork_owner, stork_instance) = setup_tests().await;
 
-    initialize_stork_default(&stork_instance, stork_owner.clone()).await.unwrap();
+    initialize_stork_default(&stork_instance, stork_owner.clone())
+        .await
+        .unwrap();
 
     // Create a third wallet for this test
     let base_asset_config = AssetConfig {
@@ -601,10 +968,7 @@ async fn test_ownership_transfer_wrong_acceptor() {
     };
 
     let mut wallets = launch_custom_provider_and_get_wallets(
-        WalletsConfig::new_multiple_assets(
-            1,
-            vec![base_asset_config],
-        ),
+        WalletsConfig::new_multiple_assets(1, vec![base_asset_config]),
         None,
         None,
     )
@@ -613,17 +977,29 @@ async fn test_ownership_transfer_wrong_acceptor() {
     let wrong_acceptor = wallets.pop().unwrap();
 
     let proposed_owner = not_stork_owner.address();
-    
+
     // Owner proposes new owner
-    stork_instance.methods().propose_owner(proposed_owner).call().await.unwrap();
+    stork_instance
+        .methods()
+        .propose_owner(proposed_owner)
+        .call()
+        .await
+        .unwrap();
 
     // Wrong account tries to accept ownership - should fail
-    let res = stork_instance.clone().with_account(wrong_acceptor).methods().accept_ownership().call().await;
+    let res = stork_instance
+        .clone()
+        .with_account(wrong_acceptor)
+        .methods()
+        .accept_ownership()
+        .call()
+        .await;
     assert!(res.is_err());
 
     // Verify ownership hasn't changed
     let owner_state = stork_instance.methods().owner().call().await.unwrap().value;
-    assert_eq!(owner_state, State::Initialized(stork_owner.address().into()));
+    assert_eq!(
+        owner_state,
+        State::Initialized(stork_owner.address().into())
+    );
 }
-
-


### PR DESCRIPTION
## H-01
Addressed in code and tested in 942365a85464b3f0556d1fe31f66dbd9c22d1834

## M-01
Acknowledged.

Most pushers will be running Stork's [open source chain pusher](https://github.com/Stork-Oracle/stork-external/blob/main/apps/docs/chain_pusher.md), which should mitigate this edge case. Stork would rather not introduce two way payment capabilities at this time. Stork reserves the capability to address this further in a future upgrade.

## L-01
Partially addressed in code and tested in 4a3b1fe744013b52b6be9d1b5db449287d00ffe6 (tests expanded in 05be0712e55d335cbe3d94093103e25e7438e02f).

Two step ownership transfer has been implemented, however Stork would rather not introduce ownership revocation at this time. Stork reserves the capability to implement ownership revocation in a future upgrade.

## L-02
Addressed in code in 91d20ef03d90c5f65d194bdf2ace4814d1ac769c.

Though ownership revocation is not currently possible, `revert(0)` has been added to the `revoked` arm of the `match` on the owner state as a best practice. Stork reserves the capability to revise this arm at such a time if/when ownership revocation is implemented.

## L-03
Partially address in code in a9f7ca6ce4c0da3f2c16695a09637df0f52c5af6

Recommendation 1 (signature malleability protection) has been implemented. Though signature malleability does **not** cause a vulnerability in this contract, EIP-2 compliance has been implemented in this regard as a best practice. 

Recommendation 2 (nonce in the stork signed messages) has not been implemented as the messages already have a strictly increasing nonce in the form of a timestamp which is checked in code.

## I-01
Acknowledged.

Initialization will be triggered manually immediately after deployment. As this is a one time action, the potential for griefing is minimal, especially as the deployer public key will not be publicized ahead of deployment.

