### PR TITLE
fix chain pusher treating failed oracle pushes as success

### DIFF
--- a/apps/chain_pusher/pkg/evm/interactor.go
+++ b/apps/chain_pusher/pkg/evm/interactor.go
@@ -26,9 +26,10 @@ import (
 )
 
 var (
-	ErrCastingPublicKeyToECDSA = errors.New("error casting public key to ECDSA")
-	ErrMaxRetryAttemptsReached = errors.New("max retry attempts reached")
-	ErrEventChannelClosed      = errors.New("event channel is closed")
+	ErrCastingPublicKeyToECDSA       = errors.New("error casting public key to ECDSA")
+	ErrMaxRetryAttemptsReached       = errors.New("max retry attempts reached")
+	ErrEventChannelClosed            = errors.New("event channel is closed")
+	ErrPublisherSignaturesNotVerified = errors.New("publisher signatures not verified")
 )
 
 const (
@@ -405,7 +406,7 @@ func (eci *ContractInteractor) BatchPushToContract(
 			if !verified {
 				eci.logger.Error().Msg("Publisher signatures not verified, skipping update")
 
-				return nil
+				return ErrPublisherSignaturesNotVerified
 			}
 		}
 	}
@@ -682,17 +683,14 @@ func (eci *ContractInteractor) submitTransaction(
 		return nil, fmt.Errorf("failed to create transaction: %w", err)
 	}
 
+	signerAddress := crypto.PubkeyToAddress(eci.privateKey.PublicKey)
+
 	if eci.useSyncSend {
 		receipt, txErr := eci.client.SendTransactionSync(ctx, tx, nil)
-		err := eci.nonceManager.IncrementNonce(ctx, eci.client, crypto.PubkeyToAddress(eci.privateKey.PublicKey))
-		if err != nil {
-			return nil, fmt.Errorf("failed to increment nonce: %w", err)
-		}
-
 		if txErr != nil {
 			if strings.Contains(txErr.Error(), "nonce") {
 				eci.logger.Warn().Err(txErr).Msg("Nonce mismatch, resetting nonce")
-				err := eci.nonceManager.ResetNonce(ctx, eci.client, crypto.PubkeyToAddress(eci.privateKey.PublicKey))
+				err := eci.nonceManager.ResetNonce(ctx, eci.client, signerAddress)
 				if err != nil {
 					return nil, fmt.Errorf("failed to reset nonce: %w", err)
 				}
@@ -701,27 +699,32 @@ func (eci *ContractInteractor) submitTransaction(
 		}
 
 		if receipt.Status != 1 {
+			err := eci.nonceManager.IncrementNonce(ctx, eci.client, signerAddress)
+			if err != nil {
+				return nil, fmt.Errorf("failed to increment nonce: %w", err)
+			}
+
 			return nil, fmt.Errorf("eth_sendRawTransactionSync transaction failed")
 		}
 	} else {
 		txErr := eci.client.SendTransaction(ctx, tx)
-		err := eci.nonceManager.IncrementNonce(ctx, eci.client, crypto.PubkeyToAddress(eci.privateKey.PublicKey))
-		if err != nil {
-			return nil, fmt.Errorf("failed to increment nonce: %w", err)
-		}
-
 		if txErr != nil {
 			if revertData, ok := ethclient.RevertErrorData(txErr); ok {
 				eci.logger.Error().Str("revertData", hex.EncodeToString(revertData)).Msg("transaction reverted with data")
 			} else if strings.Contains(txErr.Error(), "nonce") {
 				eci.logger.Warn().Err(txErr).Msg("Nonce mismatch, resetting nonce")
-				err := eci.nonceManager.ResetNonce(ctx, eci.client, crypto.PubkeyToAddress(eci.privateKey.PublicKey))
+				err := eci.nonceManager.ResetNonce(ctx, eci.client, signerAddress)
 				if err != nil {
 					return nil, fmt.Errorf("failed to reset nonce: %w", err)
 				}
 			}
 			return nil, fmt.Errorf("failed to send transaction: %w", txErr)
 		}
+	}
+
+	err = eci.nonceManager.IncrementNonce(ctx, eci.client, signerAddress)
+	if err != nil {
+		return nil, fmt.Errorf("failed to increment nonce: %w", err)
 	}
 
 	eci.gasFeeCap = tx.GasFeeCap()

--- a/apps/chain_pusher/pkg/evm/nonce_manager_test.go
+++ b/apps/chain_pusher/pkg/evm/nonce_manager_test.go
@@ -1,0 +1,26 @@
+package evm
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalNonceManagerIncrementAndReset(t *testing.T) {
+	t.Parallel()
+
+	manager := NewLocalNonceManager()
+	manager.nonce = big.NewInt(7)
+
+	err := manager.IncrementNonce(context.Background(), nil, common.Address{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(8), manager.nonce.Int64())
+
+	err = manager.ResetNonce(context.Background(), nil, common.Address{})
+	require.NoError(t, err)
+	assert.Nil(t, manager.nonce)
+}

--- a/apps/first_party_pusher/pkg/pusher/pusher.go
+++ b/apps/first_party_pusher/pkg/pusher/pusher.go
@@ -273,6 +273,8 @@ func (r *FirstPartyRunner[T]) pushBatch(
 		r.logger.Error().
 			Err(err).
 			Msg("Failed to push batch to contract")
+
+		return
 	}
 
 	r.logger.Debug().


### PR DESCRIPTION
hey team, its mooncitydev, checked the chain pusher code and found a few spots where failed oracle updates were getting treated like successes. not sure how often these hit prod but the stale price symptom looked bad enough to patch.

first one is in the evm chain pusher when verify-publishers is on. if on-chain signature verification comes back false, the code logged an error and returned nil. downstream handlePushUpdates saw that as a successful push and updated latestContractValueMap anyway, so the pusher stopped retrying while on-chain prices stayed old. now it returns ErrPublisherSignaturesNotVerified.

second is local nonce handling in submitTransaction. the nonce was getting incremented before checking whether SendTransaction actually worked. rpc errors, insufficient funds, most nonce mismatches, etc would still bump the cached nonce and the pusher could get stuck until restart. now we only increment after a send succeeds, still increment on mined reverts since the nonce was consumed, and reset on nonce errors before returning.

third is the first party pusher pushBatch path. it always updated latestContractValueMap even when BatchPushToContract failed, same stale price suppression problem. now it returns early on error.

small nonce manager test included. could not run go test locally in this env so would appreciate a ci pass.

cheers