### PR TITLE
replace dead Grove RPC endpoint for arbitrumMainnet

### DIFF
--- a/chains/evm/contracts/stork/hardhat.config.ts
+++ b/chains/evm/contracts/stork/hardhat.config.ts
@@ -61,7 +61,7 @@ const config: HardhatUserConfig = {
       chainId: 421614,
     },
     arbitrumMainnet: {
-      url: "https://arbitrum-one.rpc.grove.city/v1/01fdb492",
+      url: "https://arb1.arbitrum.io/rpc",
       accounts: [PRIVATE_KEY],
       chainId: 42161,
     },


### PR DESCRIPTION
Closes #284.

`arbitrumMainnet` points at `https://arbitrum-one.rpc.grove.city/v1/01fdb492`, and that hostname no longer exists — both Cloudflare (1.1.1.1) and Google (8.8.8.8) return **NXDOMAIN** for it, so `hardhat --network arbitrumMainnet` fails at name resolution before it ever reaches a node. `grove.city` itself still resolves, so this is the endpoint being gone rather than the provider being down.

The issue anticipated this as something to fix "before Grove's RPC service is discontinued" — as of today it has already happened.

Replaced with Arbitrum's official public endpoint. Rationale for that specific one:

- **Consistent with the neighbouring entry.** `arbitrumSepolia`, two blocks above, already uses the official `https://sepolia-rollup.arbitrum.io/rpc`.
- **Verified against this config.** `eth_chainId` on `https://arb1.arbitrum.io/rpc` returns `42161`, matching the `chainId` this network block declares. (The sibling Sepolia endpoint likewise returns `421614`, matching its own block.)
- **No third-party account id.** The old URL embedded the portal id `01fdb492`, which pointed every clone of this public repo at one account's quota with a provider none of the other networks here use. Grove appears exactly once in the repository, so nothing else depends on it.

One-line change; no other network entries touched.
